### PR TITLE
test: chaos-fuzz-extra + k8s live smoke + modern Dockerfile.live

### DIFF
--- a/Dockerfile.live
+++ b/Dockerfile.live
@@ -1,0 +1,16 @@
+# Modern minimal Dockerfile used by the k8s live-smoke test only.
+# The repo's main Dockerfile pins node:12.3.1-alpine and is too old for
+# current dev work; this image is built locally + loaded into minikube
+# via `minikube image load`. Not pushed to docker hub from this branch.
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm install --omit=dev --no-audit --no-fund --ignore-scripts
+COPY dist ./dist
+COPY assets ./assets
+ENV NODE_ENV=production \
+    live_mutex_host=0.0.0.0 \
+    live_mutex_port=6970 \
+    lmx_in_docker=yes
+EXPOSE 6970
+ENTRYPOINT ["node", "dist/lm-start-server.js"]

--- a/test/chaos-fuzz-extra-test.ts
+++ b/test/chaos-fuzz-extra-test.ts
@@ -1,0 +1,478 @@
+'use strict';
+
+/**
+ * Extra chaos / robustness scenarios for the Node.js broker.
+ *
+ * Complements `chaos-fuzz-test.ts` with four scenarios that target
+ * operational properties the existing suite does not cover:
+ *
+ *   s8  TCP-disconnect burst: N raw TCP clients each acquire on a
+ *       distinct key and slam their socket shut without releasing.
+ *       The broker must reap every holder and the queue, and a
+ *       fresh client must be able to acquire all keys again.
+ *
+ *   s9  High-contention FIFO fairness: M waiters enqueue serially on
+ *       one hot key (next waiter is started only after the previous
+ *       one is observed in `lck.notify.size`). The grant order must
+ *       match the enqueue order and fencing tokens must be strictly
+ *       monotonic across the run.
+ *
+ *  s10  TTL sweeper rescue: a client acquires a short-TTL lock and
+ *       crashes (its socket is destroyed) before releasing. After
+ *       the deadline elapses, calling `broker.tickTtl()` directly
+ *       evicts the abandoned holder and grants the next waiter.
+ *
+ *  s11  Fencing token across broker restart: a token minted by
+ *       broker A and a token minted by broker B (started after A is
+ *       closed) on the same key must be strictly increasing across
+ *       the process boundary, since the per-key fencing counter
+ *       seeds from `Date.now()` at lock creation. This protects
+ *       downstream Kleppmann consumers from accepting stale fences
+ *       after a broker rotation.
+ */
+
+import * as assert from 'assert';
+import * as net from 'net';
+import {Broker1, Client} from '../dist/main';
+import {v4 as uuidV4} from 'uuid';
+
+// =====================================================================
+// Harness — the same pickPort + startBroker pattern as chaos-fuzz-test.
+// Kept self-contained so this file can run standalone.
+// =====================================================================
+
+async function pickPort(): Promise<number> {
+    for (let attempt = 0; attempt < 32; attempt++) {
+        const candidate = 10000 + Math.floor(Math.random() * 30000);
+        const ok = await new Promise<boolean>((resolve) => {
+            const server = net.createServer();
+            server.unref();
+            server.once('error', () => resolve(false));
+            server.listen(candidate, '127.0.0.1', () => {
+                server.close(() => resolve(true));
+            });
+        });
+        if (ok) return candidate;
+    }
+    throw new Error('pickPort: could not bind any candidate port');
+}
+
+async function startBroker(): Promise<{broker: any; port: number; close: () => Promise<void>}> {
+    const port = await pickPort();
+    const broker = new Broker1({port, host: '127.0.0.1'});
+    if (broker.emitter && typeof broker.emitter.on === 'function') {
+        broker.emitter.on('warning', () => {/* suppress */});
+        broker.emitter.on('error', () => {/* suppress */});
+    }
+    await broker.ensure();
+    return {
+        broker,
+        port,
+        close: async () => {
+            await new Promise<void>(r => setTimeout(r, 30));
+            try { broker.close && broker.close(null); } catch {/* ignore */}
+        },
+    };
+}
+
+function quietClient<T extends {emitter?: any}>(c: T): T {
+    if (c.emitter && typeof c.emitter.on === 'function') {
+        c.emitter.on('warning', () => {});
+        c.emitter.on('error', () => {});
+    }
+    return c;
+}
+
+async function withTimeout<T>(label: string, ms: number, p: Promise<T>): Promise<T> {
+    let to: NodeJS.Timeout | null = null;
+    const timer = new Promise<never>((_, rej) => {
+        to = setTimeout(() => rej(new Error(`${label} timed out after ${ms}ms`)), ms);
+    });
+    try {
+        return await Promise.race([p, timer]);
+    } finally {
+        if (to) clearTimeout(to);
+    }
+}
+
+let scenarioCount = 0;
+function ok(label: string, msg: string) {
+    process.stdout.write(`  ${label}: \u2713 ${msg}\n`);
+}
+function fail(label: string, msg: string): never {
+    process.stderr.write(`  ${label}: \u2717 ${msg}\n`);
+    process.exit(1);
+}
+
+// =====================================================================
+// s8 — TCP disconnect burst
+// =====================================================================
+//
+// We deliberately use the high-level Client to acquire (so the broker
+// observes a normal handshake + Lock request), then call `client.close()`
+// which destroys the underlying socket. The broker's `cleanupConnection`
+// path is what we're exercising; it should reap every key's holder
+// regardless of who closed the socket.
+
+async function s8_tcp_disconnect_burst() {
+    const label = 's8';
+    const {broker, port, close} = await startBroker();
+    try {
+        const nClients = 40;
+        const keys = Array.from({length: nClients}, (_, i) => `s8-burst-${i}`);
+
+        const clients: any[] = [];
+        for (let i = 0; i < nClients; i++) {
+            const c = quietClient(
+                await new Client({port, lockRequestTimeout: 8_000, ttl: 30_000}).ensure(),
+            );
+            const lock = await c.acquire(keys[i], {ttl: 30_000, maxRetries: 1});
+            // Sanity: broker actually has the holder on this key.
+            const sz = broker.locks.get(keys[i])?.lockholders?.size ?? 0;
+            if (sz !== 1) {
+                fail(label, `expected 1 holder on ${keys[i]} after acquire, got ${sz}`);
+            }
+            clients.push(c);
+            // Do not store `lock`; we want the client to disappear without
+            // a release.
+            void lock;
+        }
+
+        for (const c of clients) {
+            try { c.close(); } catch {/* ignore */}
+        }
+
+        const deadline = Date.now() + 5_000;
+        let stillHeld: string[] = keys.slice();
+        while (stillHeld.length > 0 && Date.now() < deadline) {
+            await new Promise(r => setTimeout(r, 20));
+            stillHeld = stillHeld.filter(k => {
+                const lck = broker.locks.get(k);
+                const sz = lck?.lockholders?.size ?? 0;
+                const queued = lck?.notify?.size ?? 0;
+                return sz > 0 || queued > 0;
+            });
+        }
+        if (stillHeld.length > 0) {
+            fail(label, `broker did not reap holders within 5s. still held: ${stillHeld.slice(0, 5).join(', ')} (+${Math.max(0, stillHeld.length - 5)} more)`);
+        }
+
+        const probe = quietClient(
+            await new Client({port, lockRequestTimeout: 5_000, ttl: 1_000}).ensure(),
+        );
+        try {
+            for (const k of keys) {
+                const got = await probe.acquire(k, {ttl: 500, maxRetries: 2});
+                await probe.release(k, got.id);
+            }
+        } finally {
+            probe.close();
+        }
+        ok(label, `${nClients} simultaneous client disconnects reaped, every key re-acquirable`);
+    } finally {
+        await close();
+    }
+    scenarioCount++;
+}
+
+// =====================================================================
+// s9 — High-contention FIFO fairness on a single key
+// =====================================================================
+//
+// One holder + N waiters. We start each waiter's acquire ONLY after the
+// broker is observed to have enqueued the previous one, so the enqueue
+// order is deterministic. After the holder releases, the broker should
+// drain the queue in order: each waiter receives the lock in turn, with
+// strictly monotonic fencing tokens.
+//
+// `lck.notify.size` is the broker's queue depth for that key, so we
+// poll it to know when each waiter is enqueued.
+
+async function s9_high_contention_fifo() {
+    const label = 's9';
+    const {broker, port, close} = await startBroker();
+    try {
+        const key = 's9-fifo-key';
+        const nWaiters = 40;
+
+        const holder = quietClient(
+            await new Client({port, lockRequestTimeout: 60_000, ttl: 60_000}).ensure(),
+        );
+        const holderLock = await holder.acquire(key, {ttl: 60_000, maxRetries: 1});
+
+        const grantOrder: number[] = [];
+        const tokensInGrantOrder: number[] = [];
+        const releasers: Array<() => void> = [];
+        const tasks: Promise<void>[] = [];
+        const grantOrderMu: Promise<void>[] = [];
+
+        for (let waiter = 0; waiter < nWaiters; waiter++) {
+            const trigger = new Promise<void>((resolve) => {
+                releasers.push(resolve);
+            });
+            const myWaiter = waiter;
+            const startedTask = (async () => {
+                const c = quietClient(
+                    await new Client({port, lockRequestTimeout: 60_000, ttl: 60_000}).ensure(),
+                );
+                try {
+                    const lck = await c.acquire(key, {ttl: 60_000, maxRetries: 1});
+                    grantOrder.push(myWaiter);
+                    if (typeof lck.fencingToken === 'number') {
+                        tokensInGrantOrder.push(lck.fencingToken);
+                    }
+                    await trigger;
+                    await c.release(key, lck.id);
+                } finally {
+                    c.close();
+                }
+            })();
+            tasks.push(startedTask);
+
+            // Wait until this waiter is observed enqueued in the broker's
+            // notify queue before starting the next one.
+            const target = waiter + 1; // queue depth excluding holder
+            const enqDeadline = Date.now() + 10_000;
+            while (true) {
+                const lck = broker.locks.get(key);
+                const sz = lck?.notify?.size ?? 0;
+                if (sz >= target) break;
+                if (Date.now() > enqDeadline) {
+                    fail(label, `waiter ${waiter} did not enqueue: notify.size=${sz} after 10s`);
+                }
+                await new Promise(r => setTimeout(r, 5));
+            }
+        }
+
+        await holder.release(key, holderLock.id);
+        holder.close();
+
+        // Drain: trickle releasers so each grant happens, then is
+        // released, allowing the next waiter through.
+        const drainDeadline = Date.now() + 30_000;
+        let nextToTrigger = 0;
+        while (grantOrder.length < nWaiters) {
+            if (Date.now() > drainDeadline) {
+                fail(label, `only ${grantOrder.length}/${nWaiters} waiters granted after 30s`);
+            }
+            // Trigger releases for all waiters whose grant we've observed
+            // but who haven't been released yet.
+            while (nextToTrigger < grantOrder.length) {
+                const idx = nextToTrigger++;
+                releasers[grantOrder[idx]]?.();
+            }
+            await new Promise(r => setTimeout(r, 2));
+        }
+        // Trigger any remaining (in case grantOrder grew but we missed it).
+        for (const r of releasers) r();
+        await withTimeout(label, 20_000, Promise.all(tasks));
+
+        const expected = Array.from({length: nWaiters}, (_, i) => i);
+        if (grantOrder.length !== nWaiters || grantOrder.some((v, i) => v !== expected[i])) {
+            fail(label, `FIFO violated. expected ${JSON.stringify(expected)}, got ${JSON.stringify(grantOrder)}`);
+        }
+
+        if (tokensInGrantOrder.length === nWaiters) {
+            for (let i = 1; i < tokensInGrantOrder.length; i++) {
+                if (!(tokensInGrantOrder[i] > tokensInGrantOrder[i - 1])) {
+                    fail(label, `fencing tokens not strictly monotonic in grant order: ${JSON.stringify(tokensInGrantOrder)}`);
+                }
+            }
+        }
+
+        ok(label, `${nWaiters} waiters drained in FIFO order with monotonic fencing tokens`);
+    } finally {
+        await close();
+    }
+    scenarioCount++;
+}
+
+// =====================================================================
+// s10 — TTL sweeper rescues a queue blocked by an abandoned holder
+// =====================================================================
+//
+// Acquire a lock with a short TTL, then deliberately abandon it (do not
+// release, but do not close the client either — so the broker's
+// `cleanupConnection` path doesn't fire). Enqueue a waiter. Manually
+// invoke `broker.tickTtl()` to advance the sweeper synchronously, then
+// verify the waiter is granted.
+//
+// This is the inverse of s8: s8 covers "client socket dies", this
+// covers "client lives but lock TTL expires while held". Both paths
+// must drain the queue.
+
+async function s10_ttl_sweeper_rescue() {
+    const label = 's10';
+    const {broker, port, close} = await startBroker();
+    try {
+        // Stop the automatic 25ms sweeper so the test drives eviction
+        // synchronously. Without this, the auto-sweeper races with the
+        // test's `tickTtl()` call and may steal the eviction, making
+        // the manual eviction count zero.
+        broker.stopTtlSweeper();
+
+        const key = 's10-stale-key';
+
+        const holder = quietClient(
+            await new Client({port, lockRequestTimeout: 5_000, ttl: 30_000}).ensure(),
+        );
+        const holdLock = await holder.acquire(key, {ttl: 200, maxRetries: 1});
+        if ((broker.locks.get(key)?.lockholders?.size ?? 0) !== 1) {
+            fail(label, 'holder not registered in broker');
+        }
+
+        const waiter = quietClient(
+            await new Client({port, lockRequestTimeout: 10_000, ttl: 30_000}).ensure(),
+        );
+        const waiterAcq = waiter.acquire(key, {ttl: 30_000, maxRetries: 1});
+
+        // Wait for waiter to be enqueued.
+        const enqDeadline = Date.now() + 5_000;
+        while ((broker.locks.get(key)?.notify?.size ?? 0) < 1) {
+            if (Date.now() > enqDeadline) {
+                fail(label, 'waiter never enqueued');
+            }
+            await new Promise(r => setTimeout(r, 5));
+        }
+
+        // Sleep past the holder's TTL. With the auto-sweeper stopped,
+        // the holder remains in `lockholders` until we tick.
+        await new Promise(r => setTimeout(r, 250));
+        if ((broker.locks.get(key)?.lockholders?.size ?? 0) !== 1) {
+            fail(label, 'auto-sweeper still appears active — holder evicted before manual tick');
+        }
+
+        const evicted = broker.tickTtl();
+        if (evicted < 1) {
+            fail(label, `tickTtl evicted ${evicted} entries (expected >=1)`);
+        }
+
+        const grantedLock = await withTimeout(label, 5_000, waiterAcq);
+        if (!grantedLock || !grantedLock.id) {
+            fail(label, 'waiter lock object missing');
+        }
+
+        await waiter.release(key, grantedLock.id);
+        waiter.close();
+
+        try { await holder.release(key, holdLock.id); } catch {/* expected: lock already evicted */}
+        holder.close();
+
+        ok(label, 'TTL sweeper evicted abandoned holder and granted enqueued waiter');
+    } finally {
+        await close();
+    }
+    scenarioCount++;
+}
+
+// =====================================================================
+// s11 — Fencing token advances across broker restart
+// =====================================================================
+
+async function s11_fencing_advances_across_broker_restart() {
+    const label = 's11';
+    const key = 's11-restart-fence';
+
+    const a = await startBroker();
+    let tokenA: number | null = null;
+    try {
+        const c = quietClient(
+            await new Client({port: a.port, lockRequestTimeout: 5_000, ttl: 5_000}).ensure(),
+        );
+        try {
+            const got = await c.acquire(key, {ttl: 1_000, maxRetries: 1});
+            if (typeof got.fencingToken !== 'number') {
+                fail(label, 'broker A returned no fencing token');
+            }
+            tokenA = got.fencingToken;
+            await c.release(key, got.id);
+        } finally {
+            c.close();
+        }
+    } finally {
+        await a.close();
+    }
+
+    // Make sure wall-clock has advanced — the per-key fencing counter is
+    // re-seeded from `Date.now()` when broker B sees its first request
+    // for the key.
+    await new Promise(r => setTimeout(r, 15));
+
+    const b = await startBroker();
+    let tokenB: number | null = null;
+    try {
+        const c = quietClient(
+            await new Client({port: b.port, lockRequestTimeout: 5_000, ttl: 5_000}).ensure(),
+        );
+        try {
+            const got = await c.acquire(key, {ttl: 1_000, maxRetries: 1});
+            if (typeof got.fencingToken !== 'number') {
+                fail(label, 'broker B returned no fencing token');
+            }
+            tokenB = got.fencingToken;
+            await c.release(key, got.id);
+
+            // Verify the post-restart counter still grows monotonically.
+            let last = tokenB;
+            const seen = new Set<number>([tokenB]);
+            for (let i = 0; i < 16; i++) {
+                const g = await c.acquire(key, {ttl: 1_000, maxRetries: 1});
+                if (typeof g.fencingToken !== 'number') {
+                    fail(label, 'follow-up acquire returned no fencing token');
+                }
+                if (!(g.fencingToken > last)) {
+                    fail(label, `post-restart token regressed: prev=${last} next=${g.fencingToken}`);
+                }
+                if (seen.has(g.fencingToken)) {
+                    fail(label, `post-restart token duplicated: ${g.fencingToken}`);
+                }
+                seen.add(g.fencingToken);
+                last = g.fencingToken;
+                await c.release(key, g.id);
+            }
+        } finally {
+            c.close();
+        }
+    } finally {
+        await b.close();
+    }
+
+    if (!(tokenA! < tokenB!)) {
+        fail(label, `fencing token did not advance across restart: A=${tokenA} B=${tokenB}`);
+    }
+    ok(label, `tokens across restart strictly increasing: A=${tokenA} -> B=${tokenB} (+15 monotonic follow-ups)`);
+    scenarioCount++;
+}
+
+// =====================================================================
+// Driver
+// =====================================================================
+
+const watchdog = setTimeout(() => {
+    process.stderr.write(`chaos-fuzz-extra-test watchdog: total runtime exceeded budget\n`);
+    process.exit(1);
+}, 5 * 60_000);
+watchdog.unref();
+
+(async () => {
+    const scenarios: Array<[string, () => Promise<void>]> = [
+        ['s8', s8_tcp_disconnect_burst],
+        ['s9', s9_high_contention_fifo],
+        ['s10', s10_ttl_sweeper_rescue],
+        ['s11', s11_fencing_advances_across_broker_restart],
+    ];
+    for (const [name, fn] of scenarios) {
+        try {
+            await fn();
+        } catch (err: any) {
+            process.stderr.write(`scenario ${name} threw: ${err && err.stack || err}\n`);
+            process.exit(1);
+        }
+    }
+    process.stdout.write(`\n\u2705 chaos-fuzz-extra-test: all ${scenarioCount} scenarios passed\n`);
+    clearTimeout(watchdog);
+    process.exit(0);
+})().catch(err => {
+    process.stderr.write(`top-level: ${err && err.stack || err}\n`);
+    process.exit(1);
+});

--- a/test/k8s-live-smoke-test.ts
+++ b/test/k8s-live-smoke-test.ts
@@ -1,0 +1,220 @@
+'use strict';
+
+/**
+ * End-to-end smoke test against a live broker reachable on the network.
+ *
+ * Skipped (exits 0 with a notice) when `LMX_LIVE_BROKER_TCP` is unset
+ * so it doesn't break the local `npm test` matrix. Run against any
+ * deployed broker (Kubernetes Service, EC2 host, docker-compose, etc.)
+ * with:
+ *
+ *   LMX_LIVE_BROKER_TCP=host:port \
+ *   npx ts-node test/k8s-live-smoke-test.ts
+ *
+ * Each scenario exercises one slice of the public surface a typical
+ * client relies on: TCP acquire/release with fencing-token
+ * monotonicity, semaphore cap enforcement, RW read/write, and TTL
+ * sweeper rescue (eviction of an abandoned holder when the client
+ * socket closes without a release).
+ *
+ * The test does NOT assume anything about the broker's hostname
+ * (so it works equally well from inside a pod via `dd-rust-network-mutex.lmx-test.svc`
+ * or via `kubectl port-forward 127.0.0.1:6970`).
+ */
+
+import {Client, RWLockClient} from '../dist/main';
+
+function envEndpoint(): {host: string; port: number} | null {
+    const raw = process.env.LMX_LIVE_BROKER_TCP;
+    if (!raw) return null;
+    const [host, portStr] = raw.split(':');
+    if (!host || !portStr) {
+        process.stderr.write(`LMX_LIVE_BROKER_TCP must be host:port (got ${raw})\n`);
+        process.exit(1);
+    }
+    return {host, port: Number(portStr)};
+}
+
+function quiet<T extends {emitter?: any}>(c: T): T {
+    if (c.emitter && typeof c.emitter.on === 'function') {
+        c.emitter.on('warning', () => {});
+        c.emitter.on('error', () => {});
+    }
+    return c;
+}
+
+let scenarioCount = 0;
+function ok(label: string, msg: string) {
+    process.stdout.write(`  ${label}: \u2713 ${msg}\n`);
+}
+function fail(label: string, msg: string): never {
+    process.stderr.write(`  ${label}: \u2717 ${msg}\n`);
+    process.exit(1);
+}
+
+function shortSuffix(): string {
+    return Math.random().toString(36).slice(2, 10);
+}
+
+async function s_acquire_release_with_fencing(host: string, port: number) {
+    const label = 'live-1';
+    const key = `lmx-live-acq-${shortSuffix()}`;
+    const c = quiet(await new Client({host, port, lockRequestTimeout: 8_000, ttl: 5_000}).ensure());
+    try {
+        const a = await c.acquire(key, {ttl: 1_000, maxRetries: 1});
+        if (typeof a.fencingToken !== 'number') fail(label, 'no fencing token in first grant');
+        await c.release(key, a.id);
+        const b = await c.acquire(key, {ttl: 1_000, maxRetries: 1});
+        if (typeof b.fencingToken !== 'number') fail(label, 'no fencing token in second grant');
+        if (!(b.fencingToken > a.fencingToken)) {
+            fail(label, `fencing not monotonic: ${a.fencingToken} -> ${b.fencingToken}`);
+        }
+        await c.release(key, b.id);
+        ok(label, `acquire/release fencing monotonic (${a.fencingToken} \u2192 ${b.fencingToken})`);
+    } finally {
+        c.close();
+    }
+    scenarioCount++;
+}
+
+async function s_semaphore_cap_enforced(host: string, port: number) {
+    const label = 'live-2';
+    const key = `lmx-live-sem-${shortSuffix()}`;
+    const max = 3;
+
+    const holders: any[] = [];
+    const lockIds: string[] = [];
+    for (let i = 0; i < max; i++) {
+        const c = quiet(await new Client({host, port, lockRequestTimeout: 8_000, ttl: 10_000}).ensure());
+        const lk = await c.acquire(key, {ttl: 5_000, max, maxRetries: 1});
+        holders.push(c);
+        lockIds.push(lk.id);
+    }
+
+    // (max+1)-th acquire must time out — broker queues but doesn't grant.
+    // Use lockRequestTimeout=1000 with a single attempt (maxRetries=1)
+    // so the probe fails fast when the broker correctly enforces the
+    // cap. We don't try to release the probe's grant — if it ever
+    // happens, that's a hard cap-violation failure.
+    const probe = quiet(
+        await new Client({host, port, lockRequestTimeout: 1_000, ttl: 5_000}).ensure(),
+    );
+    let probeOutcome: 'rejected' | 'granted' = 'rejected';
+    let probeLockId: string | null = null;
+    try {
+        const got = await probe.acquire(key, {
+            ttl: 5_000,
+            max,
+            maxRetries: 1,
+            lockRequestTimeout: 1_000,
+        });
+        probeOutcome = 'granted';
+        probeLockId = got.id;
+    } catch {
+        // expected
+    }
+    if (probeOutcome === 'granted') {
+        // Defensive cleanup so we don't dangle a 4th holder.
+        try { if (probeLockId) await probe.release(key, probeLockId); } catch {}
+        probe.close();
+        fail(label, `broker over-granted semaphore (max=${max}) — probe got a slot`);
+    }
+    probe.close();
+
+    for (let i = 0; i < holders.length; i++) {
+        await holders[i].release(key, lockIds[i]);
+        holders[i].close();
+    }
+    ok(label, `semaphore cap=${max} held under contention`);
+    scenarioCount++;
+}
+
+async function s_rw_read_then_write(host: string, port: number) {
+    const label = 'live-3';
+    const suffix = shortSuffix();
+    // RWLockClient.beginRead requires a paired writeKey. The two keys
+    // form the read/write coordination pair: readers acquire `key`
+    // shared, while a writer holds `writeKey` exclusively.
+    const readKey = `lmx-live-rw-r-${suffix}`;
+    const writeKey = `lmx-live-rw-w-${suffix}`;
+    // The RWLockClient promise helpers (`beginReadp`/`beginWritep`) are
+    // defined on the subclass but `ensure()` is typed as returning the
+    // base `Client`, so we cast to `any` here rather than fighting the
+    // declared shape.
+    const rw: any = quiet(
+        await new RWLockClient({host, port, lockRequestTimeout: 8_000, ttl: 5_000}).ensure(),
+    );
+    try {
+        const r = await rw.beginReadp(readKey, {writeKey, ttl: 1_000, maxRetries: 1});
+        await rw.endReadp(readKey, {writeKey, id: r.id});
+        const w = await rw.beginWritep(writeKey, {ttl: 1_000, maxRetries: 1});
+        await rw.endWritep(writeKey, {id: w.id});
+        ok(label, 'RW read (readKey/writeKey pair) then write completed');
+    } finally {
+        rw.close();
+    }
+    scenarioCount++;
+}
+
+async function s_disconnect_releases_holder(host: string, port: number) {
+    const label = 'live-4';
+    const key = `lmx-live-disc-${shortSuffix()}`;
+
+    // Holder acquires, then closes its socket without releasing. A
+    // recovery client should be able to acquire shortly after.
+    const holder = quiet(
+        await new Client({host, port, lockRequestTimeout: 5_000, ttl: 30_000}).ensure(),
+    );
+    const lk = await holder.acquire(key, {ttl: 30_000, maxRetries: 1});
+    void lk;
+    holder.close();
+
+    // Use a forgiving retry budget to absorb the broker's drop-client
+    // sweep latency on the network path.
+    const recover = quiet(
+        await new Client({host, port, lockRequestTimeout: 8_000, ttl: 5_000}).ensure(),
+    );
+    try {
+        const got = await recover.acquire(key, {ttl: 1_000, maxRetries: 5});
+        await recover.release(key, got.id);
+        ok(label, 'broker reaped holder after socket close, recover client acquired');
+    } finally {
+        recover.close();
+    }
+    scenarioCount++;
+}
+
+(async () => {
+    const ep = envEndpoint();
+    if (!ep) {
+        process.stdout.write('LMX_LIVE_BROKER_TCP not set — skipping k8s live smoke\n');
+        process.exit(0);
+    }
+    process.stdout.write(`live broker: ${ep.host}:${ep.port}\n`);
+    const watchdog = setTimeout(() => {
+        process.stderr.write('k8s-live-smoke watchdog: total runtime exceeded budget\n');
+        process.exit(1);
+    }, 60_000);
+    watchdog.unref();
+
+    const scenarios: Array<[string, (h: string, p: number) => Promise<void>]> = [
+        ['live-1', s_acquire_release_with_fencing],
+        ['live-2', s_semaphore_cap_enforced],
+        ['live-3', s_rw_read_then_write],
+        ['live-4', s_disconnect_releases_holder],
+    ];
+    for (const [name, fn] of scenarios) {
+        try {
+            await fn(ep.host, ep.port);
+        } catch (err: any) {
+            process.stderr.write(`scenario ${name} threw: ${err && err.stack || err}\n`);
+            process.exit(1);
+        }
+    }
+    process.stdout.write(`\n\u2705 k8s-live-smoke-test: all ${scenarioCount} scenarios passed\n`);
+    clearTimeout(watchdog);
+    process.exit(0);
+})().catch(err => {
+    process.stderr.write(`top-level: ${err && err.stack || err}\n`);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds **4 new in-process chaos scenarios** in `test/chaos-fuzz-extra-test.ts`, **4 new live-cluster smoke scenarios** in `test/k8s-live-smoke-test.ts`, and a minimal modern `Dockerfile.live` for local minikube validation.

### `test/chaos-fuzz-extra-test.ts`

Auto-discovered by `node scripts/run-tests.js`. Complements `chaos-fuzz-test.ts`:

| scenario | invariant |
| --- | --- |
| s8  TCP-disconnect burst | 40 clients acquire on distinct keys and close sockets without releasing; `cleanupConnection` reaps every holder within 5s and keys are re-acquirable. |
| s9  High-contention FIFO | 40 waiters enqueued one-at-a-time on a single key (next waiter started only after `lck.notify.size` confirms enqueue); grant order must equal enqueue order with strictly monotonic fencing tokens. |
| s10 TTL sweeper rescue | Abandoned holder with a 200ms TTL is evicted by a synchronous `broker.tickTtl()` call (auto-sweeper stopped to make eviction count deterministic), and the enqueued waiter is granted. |
| s11 Fencing across broker restart | Tokens minted by broker A and broker B (started after A is closed) on the same key are strictly increasing across the process boundary. |

```
[8/23] Running: test/chaos-fuzz-extra-test.ts
✅ chaos-fuzz-extra-test: all 4 scenarios passed
[8/23] ✅ test/chaos-fuzz-extra-test.ts passed (1.53s)
```

### `test/k8s-live-smoke-test.ts`

Gated on `LMX_LIVE_BROKER_TCP` env var; without it, prints "skipping" and exits 0 so it doesn't break the local `npm test` matrix. Four scenarios over TCP:

- `live-1` acquire/release with fencing monotonicity
- `live-2` semaphore cap=3 enforced under contention (with explicit per-call `lockRequestTimeout` so the probe fails fast)
- `live-3` RW read then write using the read/write key pair the `RWLockClient` requires
- `live-4` disconnect reaps holder, recover client acquires

### `Dockerfile.live`

Minimal `node:20-alpine` image, omits dev deps, copies `dist/` + `assets/`, runs `dist/lm-start-server.js` on `0.0.0.0:6970`. The repo's main `Dockerfile` is still pinned to `node:12.3.1-alpine` and continues to be the upstream publish artifact; `Dockerfile.live` is opt-in for local cluster testing via `minikube image load`.

### Live-cluster validation

```bash
docker build --platform linux/arm64 -t lmx-node-live:test -f Dockerfile.live .
minikube image load lmx-node-live:test
kubectl apply -f lmx-node.yaml          # Deployment + Service in lmx-test ns
kubectl -n lmx-test port-forward svc/dd-live-mutex-node 6980:6970 &
LMX_LIVE_BROKER_TCP=127.0.0.1:6980 npx ts-node test/k8s-live-smoke-test.ts
```

```
live broker: 127.0.0.1:6980
  live-1: ✓ acquire/release fencing monotonic (1779640964916 → 1779640964917)
  live-2: ✓ semaphore cap=3 held under contention
  live-3: ✓ RW read (readKey/writeKey pair) then write completed
  live-4: ✓ broker reaped holder after socket close, recover client acquired

✅ k8s-live-smoke-test: all 4 scenarios passed
```

This confirms the Node.js broker (running as a Kubernetes Pod, reached over a real cluster Service) handles the public TCP surface correctly end-to-end.

## Test plan

- [x] `npx ts-node test/chaos-fuzz-extra-test.ts` (all 4 scenarios pass)
- [x] `node scripts/run-tests.js` discovers and runs `chaos-fuzz-extra-test.ts`
- [x] Live smoke against `lmx-node-live:test` deployed to minikube (all 4 pass)
- [ ] Live smoke against the `oresoftware/live-mutex` image once it is republished from a modern Node base — the existing `node:12.3.1-alpine` image fails to install on Apple Silicon


Made with [Cursor](https://cursor.com)