### PR TITLE
feat(admin): runtime log-level + TCP NODELAY toggles, HTMX status-page UI

### DIFF
--- a/src/broker-1.ts
+++ b/src/broker-1.ts
@@ -865,6 +865,29 @@ export class Broker1 {
         return this.socketFile || this.port;
     }
 
+    /**
+     * Runtime mutator for the TCP_NODELAY policy applied to *newly
+     * accepted* sockets. The connection-accept handler reads
+     * `self.noDelay` per-connection, so flipping this field is enough
+     * for new connections to pick up the new value; already-accepted
+     * sockets keep whatever Nagle setting they were created with.
+     *
+     * Note: Node's `net.Socket` API only exposes `setNoDelay` (Nagle).
+     * Linux's TCP_QUICKACK is intentionally NOT exposed here — the
+     * Rust broker (`rust-network-mutex-rs`) has a QUICKACK toggle on
+     * its admin surface; this Node broker deliberately limits itself
+     * to NODELAY to match the API Node ships out of the box.
+     *
+     * Returns the previous value for audit logging.
+     */
+    setNoDelay(value: boolean): boolean {
+        const routineId = 'ddl-routine-setNoDelay-Pq4';
+        routineEnter(routineId, "Broker1.setNoDelay");
+        const previous = this.noDelay;
+        this.noDelay = !!value;
+        return previous;
+    }
+
     getVersion() {
         const routineId = 'ddl-routine-zX08q5PMXrIcL-yTOy';
         routineEnter(routineId, "Broker1.getVersion");

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -2,6 +2,7 @@
 
 
 import {routineEnter, isOtelEnabled, setOtelEnabled} from './routine';
+import {getLogLevel, setLogLevel, LMXLogLevel} from './log-level';
 
 /// Shared admin token used to gate `/admin/*` endpoints. Defaults to
 /// the literal string the user explicitly chose; operators can
@@ -38,7 +39,7 @@ function adminToken(): string {
  */
 
 import * as http from 'http';
-import {URL} from 'url';
+import {URL, URLSearchParams} from 'url';
 import {Broker1} from './broker-1';
 import {InProcessBridge} from './in-process-bridge';
 
@@ -192,21 +193,28 @@ export class LMXHttpServer {
         // can flip the flag without redeploying. The default token is
         // the literal value baked in by request; override via the
         // `LMX_ADMIN_TOKEN` env var in production.
+        //
+        // POST accepts BOTH `application/json` and
+        // `application/x-www-form-urlencoded` bodies — the latter is
+        // what HTMX sends from the status page by default. On HX-Request
+        // we reply with an HTML snippet that HTMX swaps into a target
+        // span; everyone else still gets JSON.
         if (path === '/admin/otel') {
             if (!this.checkAdminAuth(req, res)) return;
             if (method === 'GET') {
                 return this.respondJson(res, 200, {enabled: isOtelEnabled()});
             }
             if (method === 'POST') {
-                const body = await this.readJsonBody(req, res);
+                const body = await this.readPostBody(req, res);
                 if (!body) return;
-                if (typeof body.enabled !== 'boolean') {
-                    return this.respondJson(res, 400, {
+                const enabled = coerceBool((body as any).enabled);
+                if (enabled === null) {
+                    return this.respondAdmin(req, res, 400, 'otel', {
                         error: '`enabled` is required and must be a boolean.',
                     });
                 }
-                const previous = setOtelEnabled(body.enabled);
-                return this.respondJson(res, 200, {
+                const previous = setOtelEnabled(enabled);
+                return this.respondAdmin(req, res, 200, 'otel', {
                     previous,
                     enabled: isOtelEnabled(),
                 });
@@ -216,7 +224,142 @@ export class LMXHttpServer {
             });
         }
 
+        // Admin surface — runtime log level. Backed by the dedicated
+        // `src/log-level.ts` module so gating is centralised; flipping
+        // the level here immediately quiets (or re-enables) the noisy
+        // `routineEnter` stdout writes that are emitted on every
+        // function entry across the broker.
+        if (path === '/admin/log-level') {
+            if (!this.checkAdminAuth(req, res)) return;
+            if (method === 'GET') {
+                return this.respondJson(res, 200, {level: getLogLevel()});
+            }
+            if (method === 'POST') {
+                const body = await this.readPostBody(req, res);
+                if (!body) return;
+                const rawLevel = (body as any).level;
+                if (typeof rawLevel !== 'string') {
+                    return this.respondAdmin(req, res, 400, 'log-level', {
+                        error: '`level` is required and must be a string.',
+                    });
+                }
+                try {
+                    const previous = setLogLevel(rawLevel as LMXLogLevel);
+                    return this.respondAdmin(req, res, 200, 'log-level', {
+                        previous,
+                        level: getLogLevel(),
+                    });
+                } catch (err) {
+                    return this.respondAdmin(req, res, 400, 'log-level', {
+                        error: String((err as Error)?.message || err),
+                    });
+                }
+            }
+            return this.respondJson(res, 405, {
+                error: `${method} not allowed on /admin/log-level; use GET or POST.`,
+            });
+        }
+
+        // Admin surface — TCP_NODELAY toggle. Flips
+        // `Broker1.noDelay`; new accepted sockets pick the new value
+        // up immediately (the connection-accept handler reads
+        // `self.noDelay` per-connection). Already-established
+        // connections keep their original Nagle setting.
+        //
+        // Node's net.Socket API does not expose TCP_QUICKACK; the
+        // Rust broker has the QUICKACK toggle and this Node broker
+        // intentionally limits itself to NODELAY to match the API
+        // Node ships out of the box.
+        if (path === '/admin/tcp') {
+            if (!this.checkAdminAuth(req, res)) return;
+            if (method === 'GET') {
+                return this.respondJson(res, 200, {nodelay: this.broker.noDelay});
+            }
+            if (method === 'POST') {
+                const body = await this.readPostBody(req, res);
+                if (!body) return;
+                const nodelay = coerceBool((body as any).nodelay);
+                if (nodelay === null) {
+                    return this.respondAdmin(req, res, 400, 'tcp', {
+                        error: '`nodelay` is required and must be a boolean.',
+                    });
+                }
+                const previous = this.broker.setNoDelay(nodelay);
+                return this.respondAdmin(req, res, 200, 'tcp', {
+                    previous,
+                    nodelay: this.broker.noDelay,
+                });
+            }
+            return this.respondJson(res, 405, {
+                error: `${method} not allowed on /admin/tcp; use GET or POST.`,
+            });
+        }
+
         return this.respondJson(res, 404, {error: `No route for ${method} ${path}.`});
+    }
+
+    /// Negotiate the response shape for an `/admin/*` POST: HTML for
+    /// HTMX-driven status-page clicks (`HX-Request: true`), JSON for
+    /// everyone else (curl, scripts, the existing test harness).
+    private respondAdmin(
+        req: http.IncomingMessage,
+        res: http.ServerResponse,
+        status: number,
+        target: 'otel' | 'log-level' | 'tcp',
+        body: any,
+    ): void {
+        const routineId = 'ddl-routine-respondAdmin-Js2';
+        routineEnter(routineId, "LMXHttpServer.respondAdmin");
+        if (isHxRequest(req)) {
+            const snippet = renderAdminHxSnippet(target, body);
+            if (!res.headersSent) {
+                res.writeHead(status, {'Content-Type': 'text/html; charset=utf-8'});
+                res.end(snippet);
+            }
+            return;
+        }
+        return this.respondJson(res, status, body);
+    }
+
+    /// Parse a POST body as either JSON (`application/json`) or
+    /// `application/x-www-form-urlencoded`. Form fields come in as
+    /// strings; callers coerce per-field via `coerceBool`. Returns
+    /// `null` after sending a 413/400 if the body is malformed —
+    /// callers must check and early-return.
+    private async readPostBody(
+        req: http.IncomingMessage,
+        res: http.ServerResponse,
+    ): Promise<Record<string, unknown> | null> {
+        const routineId = 'ddl-routine-readPostBody-Ld8';
+        routineEnter(routineId, "LMXHttpServer.readPostBody");
+        const chunks: Buffer[] = [];
+        let total = 0;
+        for await (const chunk of req) {
+            const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+            total += buf.length;
+            if (total > this.opts.maxBodyBytes) {
+                this.respondJson(res, 413, {error: `Body exceeds ${this.opts.maxBodyBytes} bytes.`});
+                return null;
+            }
+            chunks.push(buf);
+        }
+        const text = Buffer.concat(chunks as unknown as Uint8Array[]).toString('utf8');
+        if (text.length === 0) return {};
+        const ctype = String(req.headers['content-type'] || '').toLowerCase();
+        if (ctype.includes('application/x-www-form-urlencoded')) {
+            const out: Record<string, string> = {};
+            const params = new URLSearchParams(text);
+            params.forEach((v: string, k: string) => { out[k] = v; });
+            return out;
+        }
+        // Default to JSON. Keep behaviour identical to the legacy
+        // `readJsonBody` for callers that don't set a Content-Type.
+        try {
+            return JSON.parse(text);
+        } catch {
+            this.respondJson(res, 400, {error: 'Body must be valid JSON or application/x-www-form-urlencoded.'});
+            return null;
+        }
     }
 
     /// Validate the admin shared-secret on inbound requests to
@@ -454,6 +597,117 @@ function renderStatusHtml(broker: Broker1): string {
   </tbody>
 </table>
 
+<h2 style="margin-top: 28px; font-size: 16px;">Admin controls</h2>
+<!--
+  HTMX-driven admin UI. The page deliberately ships ZERO local JS or
+  CSS assets: htmx is pulled from the unpkg CDN with an SRI integrity
+  hash, and the single inline script tag below only handles the
+  localStorage-backed token (injected as x-admin-token on every htmx
+  request via the htmx:configRequest event). All hx-post URLs are
+  RELATIVE (no leading slash) so the page keeps working behind a
+  gateway prefix such as /lmx-node/.
+-->
+<script
+  src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"
+  integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"
+  crossorigin="anonymous"></script>
+
+<form id="lmx-admin" onsubmit="return false;">
+  <div style="margin-bottom: 12px;">
+    <label>Admin token
+      <input id="lmx-admin-token-input" type="password" autocomplete="off" />
+    </label>
+    <button id="lmx-save-token" type="button">Save token (this browser)</button>
+    <span id="lmx-save-status" style="color: var(--muted); margin-left: 8px;"></span>
+  </div>
+
+  <fieldset style="margin-bottom: 8px;">
+    <legend>Telemetry (OTel)</legend>
+    <button type="button"
+            hx-post="admin/otel"
+            hx-vals='{"enabled": "true"}'
+            hx-target="#lmx-otel-status"
+            hx-swap="innerHTML">Enable</button>
+    <button type="button"
+            hx-post="admin/otel"
+            hx-vals='{"enabled": "false"}'
+            hx-target="#lmx-otel-status"
+            hx-swap="innerHTML">Disable</button>
+    <span id="lmx-otel-status" style="margin-left: 8px;">otel: <strong>${esc(isOtelEnabled() ? 'on' : 'off')}</strong></span>
+  </fieldset>
+
+  <fieldset style="margin-bottom: 8px;">
+    <legend>Log level</legend>
+    <select id="lmx-log-level" name="level">
+      <option>silent</option><option>error</option><option>warn</option>
+      <option>info</option><option>debug</option><option>trace</option>
+    </select>
+    <button type="button"
+            hx-post="admin/log-level"
+            hx-include="#lmx-log-level"
+            hx-target="#lmx-log-status"
+            hx-swap="innerHTML">Apply</button>
+    <span id="lmx-log-status" style="margin-left: 8px;">level: <strong>${esc(getLogLevel())}</strong></span>
+  </fieldset>
+
+  <fieldset style="margin-bottom: 8px;">
+    <legend>TCP_NODELAY (new connections)</legend>
+    <button type="button"
+            hx-post="admin/tcp"
+            hx-vals='{"nodelay": "true"}'
+            hx-target="#lmx-tcp-status"
+            hx-swap="innerHTML">On</button>
+    <button type="button"
+            hx-post="admin/tcp"
+            hx-vals='{"nodelay": "false"}'
+            hx-target="#lmx-tcp-status"
+            hx-swap="innerHTML">Off</button>
+    <span id="lmx-tcp-status" style="margin-left: 8px;">nodelay: <strong>${esc(broker.noDelay ? 'on' : 'off')}</strong></span>
+  </fieldset>
+</form>
+
+<script>
+// Inline-only glue: persist the admin token to localStorage and
+// attach it as x-admin-token on every htmx request. We intentionally
+// do NOT serve a local JS file from the broker - the only JS that
+// runs on this page is htmx (from unpkg, SRI-verified) and this short
+// inline handler.
+(function () {
+  var TOKEN_KEY = 'lmx-admin-token';
+
+  function getToken() {
+    try { return window.localStorage.getItem(TOKEN_KEY) || ''; }
+    catch (e) { return ''; }
+  }
+
+  // Pre-populate the input from localStorage so reload reflects the
+  // currently-saved token. The input is type="password" so the value
+  // isn't shoulder-surf-visible.
+  document.addEventListener('DOMContentLoaded', function () {
+    var input = document.getElementById('lmx-admin-token-input');
+    if (input) input.value = getToken();
+  });
+
+  document.body.addEventListener('htmx:configRequest', function (e) {
+    var t = getToken();
+    if (t) e.detail.headers['x-admin-token'] = t;
+  });
+
+  document.getElementById('lmx-save-token').addEventListener('click', function () {
+    var input = document.getElementById('lmx-admin-token-input');
+    var v = (input && input.value || '').trim();
+    var statusEl = document.getElementById('lmx-save-status');
+    try {
+      if (v) window.localStorage.setItem(TOKEN_KEY, v);
+      else window.localStorage.removeItem(TOKEN_KEY);
+      if (statusEl) statusEl.textContent = v ? 'saved' : 'cleared';
+    } catch (err) {
+      if (statusEl) statusEl.textContent = 'localStorage unavailable';
+    }
+  });
+})();
+</script>
+
 <footer>
   <a href="/v1/stats">JSON</a> · <a href="/metrics">Prometheus</a> · <a href="/healthz">Health</a> · auto-refresh 5s
 </footer>
@@ -470,6 +724,56 @@ function esc(s: any): string {
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
+}
+
+/// Coerce JSON booleans + form-urlencoded string booleans (`"true"`,
+/// `"false"`, case-insensitive) into a real boolean. Returns `null`
+/// for anything that doesn't unambiguously map; callers turn that
+/// into a 400.
+function coerceBool(v: any): boolean | null {
+    if (typeof v === 'boolean') return v;
+    if (typeof v === 'string') {
+        const s = v.trim().toLowerCase();
+        if (s === 'true') return true;
+        if (s === 'false') return false;
+    }
+    return null;
+}
+
+/// HTMX tags every request it issues with `HX-Request: true`. We use
+/// that header as a content-negotiation signal: when present, admin
+/// endpoints respond with an HTML snippet sized for an in-place swap;
+/// otherwise they respond with JSON (curl, scripts, tests).
+function isHxRequest(req: http.IncomingMessage): boolean {
+    const v = (req.headers['hx-request'] || '').toString().trim().toLowerCase();
+    return v === 'true';
+}
+
+/// Render the tiny HTML snippet that HTMX swaps into the status-page
+/// status span for a given admin target. `body` is the same shape the
+/// JSON branch returns (`{enabled,...}` / `{level,...}` /
+/// `{nodelay,...}` / `{error,...}`). All interpolated values flow
+/// through `esc()` because the JSON shape includes operator-supplied
+/// strings (the `level` field in particular).
+function renderAdminHxSnippet(
+    target: 'otel' | 'log-level' | 'tcp',
+    body: any,
+): string {
+    if (body && typeof body.error === 'string') {
+        return `<span style="color: var(--warn);">error: ${esc(body.error)}</span>`;
+    }
+    if (target === 'otel') {
+        const on = !!body.enabled;
+        return `otel: <strong>${on ? 'on' : 'off'}</strong>`;
+    }
+    if (target === 'log-level') {
+        return `level: <strong>${esc(body.level)}</strong>`;
+    }
+    if (target === 'tcp') {
+        const on = !!body.nodelay;
+        return `nodelay: <strong>${on ? 'on' : 'off'}</strong>`;
+    }
+    return esc(JSON.stringify(body));
 }
 
 export default LMXHttpServer;

--- a/src/log-level.ts
+++ b/src/log-level.ts
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * Runtime-mutable log level for the broker.
+ *
+ * The broker has no real logger abstraction yet; this module is the
+ * minimum viable shim so the HTTP admin endpoint `/admin/log-level`
+ * can dampen the noisy `routineEnter` stdout stream at runtime without
+ * a restart.
+ *
+ * Hierarchy (low -> high verbosity):
+ *
+ *     silent < error < warn < info < debug < trace
+ *
+ * A line emitted at level `info` is shown if and only if
+ * `getLogLevel() >= info` — i.e. when the configured level is `info`,
+ * `debug`, or `trace`.
+ *
+ * Default value comes from `process.env.LMX_LOG_LEVEL` if it parses
+ * to a valid level, otherwise `'info'`.
+ */
+
+export type LMXLogLevel =
+    | 'silent'
+    | 'error'
+    | 'warn'
+    | 'info'
+    | 'debug'
+    | 'trace';
+
+const LEVELS: ReadonlyArray<LMXLogLevel> = [
+    'silent',
+    'error',
+    'warn',
+    'info',
+    'debug',
+    'trace',
+];
+
+const LEVEL_RANK: Readonly<Record<LMXLogLevel, number>> = {
+    silent: 0,
+    error: 1,
+    warn: 2,
+    info: 3,
+    debug: 4,
+    trace: 5,
+};
+
+function parseLevel(raw: string | undefined): LMXLogLevel | null {
+    if (!raw) return null;
+    const norm = raw.trim().toLowerCase();
+    if ((LEVELS as ReadonlyArray<string>).includes(norm)) {
+        return norm as LMXLogLevel;
+    }
+    return null;
+}
+
+let currentLevel: LMXLogLevel = parseLevel(process.env.LMX_LOG_LEVEL) || 'info';
+
+/** Read-only accessor for the current runtime log level. */
+export function getLogLevel(): LMXLogLevel {
+    return currentLevel;
+}
+
+/**
+ * Update the runtime log level. Returns the previous value so the
+ * caller (e.g. the HTTP admin endpoint) can include it in an audit
+ * log.
+ *
+ * Throws `Error` on invalid input; the HTTP handler converts the
+ * throw into a 400 response.
+ */
+export function setLogLevel(level: LMXLogLevel): LMXLogLevel {
+    const parsed = parseLevel(level as string);
+    if (!parsed) {
+        throw new Error(
+            `invalid log level "${level}"; expected one of: ${LEVELS.join(', ')}.`,
+        );
+    }
+    const previous = currentLevel;
+    currentLevel = parsed;
+    return previous;
+}
+
+/**
+ * Returns true if a message at `messageLevel` should be emitted given
+ * the current runtime level. Internal helper consumed by callers that
+ * want to gate `console.*` or `process.stdout.write` invocations.
+ *
+ * `silent` always returns false; messages emitted at `silent` would
+ * be invisible anyway, so we treat the call as a no-op gate.
+ */
+export function isLogLevelEnabled(messageLevel: LMXLogLevel): boolean {
+    if (messageLevel === 'silent') return false;
+    return LEVEL_RANK[currentLevel] >= LEVEL_RANK[messageLevel];
+}
+
+/** List of all valid log levels (for validation / documentation). */
+export const LMX_LOG_LEVELS: ReadonlyArray<LMXLogLevel> = LEVELS;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ export {Broker1, LMXBroker as LMXBroker1, LvMtxBroker as LvMtxBroker1} from './b
 export {LMXHttpServer} from './http-server';
 export {InProcessBridge} from './in-process-bridge';
 export {routineEnter, initOtel, shutdownOtel, setOtelEnabled, isOtelEnabled} from './routine';
+export {getLogLevel, setLogLevel, isLogLevelEnabled, LMX_LOG_LEVELS} from './log-level';
+export type {LMXLogLevel} from './log-level';
 
 export {LMXLockRequestError, LMXUnlockRequestError} from "./shared-internal";
 export {LMXClientException, LMXClientLockException, LMXClientUnlockException} from "./exceptions";

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -90,6 +90,7 @@ import {
   DiagConsoleLogger,
   DiagLogLevel,
 } from '@opentelemetry/api';
+import { isLogLevelEnabled } from './log-level';
 
 const SERVICE_NAME_DEFAULT = 'live-mutex';
 
@@ -130,9 +131,17 @@ export function routineEnter(routineId: string, codeFunction: string): void {
   //    so it has zero `console.*` overhead in tests that pipe stdout to a
   //    file. No chalk colours: this can run in test/non-tty contexts where
   //    ANSI escape codes would corrupt downstream parsers.
-  process.stdout.write(
-    `lmx routine: routineId=${routineId} fn=${codeFunction} event=enter\n`,
-  );
+  //
+  //    Gated on the runtime log level (see `src/log-level.ts` and the
+  //    `POST /admin/log-level` endpoint). The line is classified as
+  //    `info` so the default level still emits it; setting the level
+  //    to `silent`, `error`, or `warn` at runtime quiets it without a
+  //    restart.
+  if (isLogLevelEnabled('info')) {
+    process.stdout.write(
+      `lmx routine: routineId=${routineId} fn=${codeFunction} event=enter\n`,
+    );
+  }
 
   // 2. OTel span — gated on the runtime kill-switch `otelEnabled`. When
   //    off, we skip the startSpan/end pair entirely so there is zero
@@ -169,9 +178,11 @@ export function setOtelEnabled(enabled: boolean): boolean {
   const fnRoutineId = 'ddl-routine-setOtelEnabled-Tg5';
   const previous = otelEnabled;
   otelEnabled = !!enabled;
-  process.stdout.write(
-    `lmx otel: ${fnRoutineId} fn=setOtelEnabled previous=${previous} next=${otelEnabled}\n`,
-  );
+  if (isLogLevelEnabled('info')) {
+    process.stdout.write(
+      `lmx otel: ${fnRoutineId} fn=setOtelEnabled previous=${previous} next=${otelEnabled}\n`,
+    );
+  }
   return previous;
 }
 

--- a/test/admin-controls-test.ts
+++ b/test/admin-controls-test.ts
@@ -1,0 +1,410 @@
+'use strict';
+
+/**
+ * Regression suite for the runtime admin controls: `/admin/log-level`
+ * and `/admin/tcp`, plus the HTMX-driven status-page UI.
+ *
+ * Asserts:
+ *   1. `/admin/log-level` requires a token (401 without).
+ *   2. Authenticated GET returns the current level.
+ *   3. POST `{"level":"warn"}` (JSON) updates the level and reports
+ *      the previous value for audit.
+ *   4. Subsequent GET reflects the updated level.
+ *   5. POST `{"level":"bogus"}` returns 400.
+ *   6. `/admin/tcp` requires a token; GET reflects `Broker1.noDelay`;
+ *      POST flips it; POST `{}` returns 400.
+ *   7. `admin endpoints return HTML for HX-Request, JSON otherwise` —
+ *      all three POST endpoints, both content-types (form-urlencoded
+ *      + JSON), exercised in one block.
+ *   8. The HTML status page:
+ *        a. loads htmx from the pinned unpkg CDN URL with the exact
+ *           SRI integrity hash.
+ *        b. uses RELATIVE admin paths in every `hx-post` (no leading
+ *           slash → works behind a gateway prefix).
+ *        c. references the localStorage key `lmx-admin-token`.
+ *        d. contains the form id `lmx-admin`.
+ *   9. Setting `setLogLevel('silent')` suppresses subsequent
+ *      `routineEnter` stdout writes; restoring to `info` re-enables
+ *      them.
+ */
+
+import * as assert from 'assert';
+import * as http from 'http';
+import {URLSearchParams} from 'url';
+import {
+    Broker1,
+    LMXHttpServer,
+    getLogLevel,
+    setLogLevel,
+    routineEnter,
+} from '../dist/main';
+
+function fail(msg: string): never {
+    console.error('\u274c FAIL:', msg);
+    process.exit(1);
+}
+
+function ok(msg: string) {
+    console.log('  \u2713', msg);
+}
+
+const watchdog = setTimeout(() => {
+    console.error('\u274c TIMEOUT: admin-controls-test took too long');
+    process.exit(1);
+}, 15_000);
+watchdog.unref();
+
+interface HttpReply {
+    status: number;
+    body: any;
+    raw: string;
+    contentType: string;
+}
+
+function httpReq(
+    port: number,
+    method: 'GET' | 'POST',
+    path: string,
+    headers: Record<string, string>,
+    rawBody?: string,
+): Promise<HttpReply> {
+    return new Promise((resolve, reject) => {
+        const req = http.request(
+            {method, host: '127.0.0.1', port, path, headers},
+            res => {
+                const chunks: Buffer[] = [];
+                res.on('data', c => chunks.push(c));
+                res.on('end', () => {
+                    const raw = Buffer.concat(chunks as unknown as Uint8Array[]).toString('utf8');
+                    const contentType = (res.headers['content-type'] || '').toString().toLowerCase();
+                    let parsed: any = null;
+                    if (contentType.includes('application/json')) {
+                        try { parsed = JSON.parse(raw); } catch { /* leave null */ }
+                    }
+                    resolve({status: res.statusCode || 0, body: parsed, raw, contentType});
+                });
+            },
+        );
+        req.on('error', reject);
+        if (rawBody !== undefined) req.write(rawBody);
+        req.end();
+    });
+}
+
+function httpJson(
+    port: number,
+    method: 'GET' | 'POST',
+    path: string,
+    headers: Record<string, string>,
+    body?: any,
+): Promise<HttpReply> {
+    const rawBody = body !== undefined ? JSON.stringify(body) : undefined;
+    const finalHeaders: Record<string, string> = {
+        ...(rawBody ? {'Content-Type': 'application/json'} : {}),
+        ...headers,
+    };
+    return httpReq(port, method, path, finalHeaders, rawBody);
+}
+
+function httpForm(
+    port: number,
+    method: 'POST',
+    path: string,
+    headers: Record<string, string>,
+    fields: Record<string, string>,
+): Promise<HttpReply> {
+    const params = new URLSearchParams();
+    for (const k of Object.keys(fields)) params.append(k, fields[k]);
+    const rawBody = params.toString();
+    const finalHeaders: Record<string, string> = {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...headers,
+    };
+    return httpReq(port, method, path, finalHeaders, rawBody);
+}
+
+async function main() {
+    const TOKEN = 'all-dogs-go-to-heaven';
+    setLogLevel('info');
+
+    const broker = new Broker1({noListen: true, port: 0, host: '127.0.0.1'});
+    broker.emitter.on('warning', () => { /* swallow */ });
+    const httpServer = new LMXHttpServer(broker, {
+        port: 0,
+        host: '127.0.0.1',
+        enableHtmlStatus: true,
+    });
+    await httpServer.start();
+    const port: number = (httpServer as any).server.address().port;
+    if (!port) fail('HTTP server did not bind a port');
+
+    try {
+        // --- /admin/log-level (legacy JSON path) --------------------
+        {
+            const get401 = await httpJson(port, 'GET', '/admin/log-level', {});
+            assert.strictEqual(get401.status, 401, 'GET log-level without token should be 401');
+            const post401 = await httpJson(port, 'POST', '/admin/log-level', {}, {level: 'warn'});
+            assert.strictEqual(post401.status, 401, 'POST log-level without token should be 401');
+            ok('/admin/log-level rejects unauthenticated requests');
+        }
+        {
+            const r = await httpJson(port, 'GET', '/admin/log-level', {'x-admin-token': TOKEN});
+            assert.strictEqual(r.status, 200);
+            assert.strictEqual(r.body.level, 'info', 'expected initial level to be info');
+            ok('GET /admin/log-level reports current level');
+        }
+        {
+            const r = await httpJson(
+                port, 'POST', '/admin/log-level',
+                {'x-admin-token': TOKEN},
+                {level: 'warn'},
+            );
+            assert.strictEqual(r.status, 200);
+            assert.strictEqual(r.body.previous, 'info');
+            assert.strictEqual(r.body.level, 'warn');
+            assert.strictEqual(getLogLevel(), 'warn', 'in-process log level did not flip');
+            ok('POST /admin/log-level updates the level and reports previous (JSON)');
+        }
+        {
+            const r = await httpJson(port, 'GET', '/admin/log-level', {'x-admin-token': TOKEN});
+            assert.strictEqual(r.body.level, 'warn', 'subsequent GET should reflect new level');
+            ok('subsequent GET reflects updated level');
+        }
+        {
+            const r = await httpJson(
+                port, 'POST', '/admin/log-level',
+                {'x-admin-token': TOKEN},
+                {level: 'bogus'},
+            );
+            assert.strictEqual(r.status, 400, 'invalid log level should return 400');
+            ok('POST /admin/log-level rejects invalid level with 400');
+        }
+        {
+            const r = await httpJson(
+                port, 'POST', '/admin/log-level',
+                {'x-admin-token': TOKEN},
+                {},
+            );
+            assert.strictEqual(r.status, 400, 'missing level should return 400');
+            ok('POST /admin/log-level missing field returns 400');
+        }
+        setLogLevel('info');
+
+        // --- /admin/tcp ---------------------------------------------
+        {
+            const get401 = await httpJson(port, 'GET', '/admin/tcp', {});
+            assert.strictEqual(get401.status, 401);
+            const post401 = await httpJson(port, 'POST', '/admin/tcp', {}, {nodelay: false});
+            assert.strictEqual(post401.status, 401);
+            ok('/admin/tcp rejects unauthenticated requests');
+        }
+        {
+            const r = await httpJson(port, 'GET', '/admin/tcp', {'x-admin-token': TOKEN});
+            assert.strictEqual(r.status, 200);
+            assert.strictEqual(r.body.nodelay, true, 'default broker noDelay is true');
+            ok('GET /admin/tcp reports current nodelay value');
+        }
+        {
+            const r = await httpJson(
+                port, 'POST', '/admin/tcp',
+                {'x-admin-token': TOKEN},
+                {nodelay: false},
+            );
+            assert.strictEqual(r.status, 200);
+            assert.strictEqual(r.body.previous, true);
+            assert.strictEqual(r.body.nodelay, false);
+            assert.strictEqual(broker.noDelay, false, 'broker.noDelay should be flipped');
+
+            const back = await httpJson(
+                port, 'POST', '/admin/tcp',
+                {'x-admin-token': TOKEN},
+                {nodelay: true},
+            );
+            assert.strictEqual(back.body.nodelay, true);
+            assert.strictEqual(broker.noDelay, true);
+            ok('POST /admin/tcp flips noDelay and round-trips');
+        }
+        {
+            const r = await httpJson(
+                port, 'POST', '/admin/tcp',
+                {'x-admin-token': TOKEN},
+                {},
+            );
+            assert.strictEqual(r.status, 400, 'empty body should be 400');
+            const wrongType = await httpJson(
+                port, 'POST', '/admin/tcp',
+                {'x-admin-token': TOKEN},
+                {nodelay: 'yes'},
+            );
+            assert.strictEqual(wrongType.status, 400, 'non-boolean nodelay should be 400');
+            ok('POST /admin/tcp rejects missing/non-boolean nodelay with 400');
+        }
+
+        // --- admin endpoints return HTML for HX-Request, JSON otherwise
+        {
+            // (a) /admin/otel via HTMX (form-urlencoded + HX-Request: true)
+            const r = await httpForm(
+                port, 'POST', '/admin/otel',
+                {'x-admin-token': TOKEN, 'HX-Request': 'true'},
+                {enabled: 'true'},
+            );
+            assert.strictEqual(r.status, 200, 'HTMX otel POST should be 200');
+            assert.ok(r.contentType.includes('text/html'),
+                `HX-Request should yield text/html, got: ${r.contentType}`);
+            assert.ok(/otel:\s*<strong>on<\/strong>/.test(r.raw),
+                `expected HTML snippet 'otel: <strong>on</strong>', got: ${r.raw}`);
+            assert.strictEqual(r.body, null, 'HX response is not JSON');
+
+            // Flip back via HTMX too — confirm the in-process flag flipped.
+            const r2 = await httpForm(
+                port, 'POST', '/admin/otel',
+                {'x-admin-token': TOKEN, 'HX-Request': 'true'},
+                {enabled: 'false'},
+            );
+            assert.ok(/otel:\s*<strong>off<\/strong>/.test(r2.raw),
+                `expected HTML snippet 'otel: <strong>off</strong>', got: ${r2.raw}`);
+
+            // (b) /admin/log-level via HTMX
+            const rl = await httpForm(
+                port, 'POST', '/admin/log-level',
+                {'x-admin-token': TOKEN, 'HX-Request': 'true'},
+                {level: 'debug'},
+            );
+            assert.strictEqual(rl.status, 200);
+            assert.ok(rl.contentType.includes('text/html'));
+            assert.ok(/level:\s*<strong>debug<\/strong>/.test(rl.raw),
+                `expected HTML snippet 'level: <strong>debug</strong>', got: ${rl.raw}`);
+            assert.strictEqual(getLogLevel(), 'debug', 'log level should flip via HTMX form post');
+
+            // (c) /admin/tcp via HTMX
+            const rt = await httpForm(
+                port, 'POST', '/admin/tcp',
+                {'x-admin-token': TOKEN, 'HX-Request': 'true'},
+                {nodelay: 'false'},
+            );
+            assert.strictEqual(rt.status, 200);
+            assert.ok(rt.contentType.includes('text/html'));
+            assert.ok(/nodelay:\s*<strong>off<\/strong>/.test(rt.raw),
+                `expected 'nodelay: <strong>off</strong>', got: ${rt.raw}`);
+            assert.strictEqual(broker.noDelay, false);
+
+            // (d) Without HX-Request, the same form-urlencoded post
+            //     still works but returns JSON (no breaking change for
+            //     plain curl users sending forms).
+            const rj = await httpForm(
+                port, 'POST', '/admin/tcp',
+                {'x-admin-token': TOKEN},
+                {nodelay: 'true'},
+            );
+            assert.strictEqual(rj.status, 200);
+            assert.ok(rj.contentType.includes('application/json'),
+                `without HX-Request expected JSON, got: ${rj.contentType}`);
+            assert.strictEqual(rj.body.nodelay, true);
+            assert.strictEqual(rj.body.previous, false);
+            ok('admin endpoints return HTML for HX-Request, JSON otherwise');
+        }
+        setLogLevel('info');
+
+        // --- Status page HTMX integration ---------------------------
+        {
+            const r = await httpReq(port, 'GET', '/', {});
+            assert.strictEqual(r.status, 200);
+            // (8a) htmx loaded from unpkg with the exact pinned URL +
+            //      SRI hash specified by the operator.
+            assert.ok(
+                r.raw.includes('src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"'),
+                'status page should load htmx from the pinned unpkg CDN URL',
+            );
+            assert.ok(
+                r.raw.includes('integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"'),
+                'status page should include the exact SRI integrity hash',
+            );
+            assert.ok(
+                r.raw.includes('crossorigin="anonymous"'),
+                'CDN script tag must include crossorigin="anonymous" for SRI to apply',
+            );
+            ok('status page loads htmx from unpkg CDN with SRI');
+
+            // (8b) Every hx-post is a relative URL — no leading-slash.
+            //      Leading slashes would bypass the `/lmx-node/`
+            //      gateway prefix in production.
+            assert.ok(
+                !/hx-post=["']\/admin\//.test(r.raw),
+                'status page must NOT use leading-slash /admin paths in hx-post (would bypass gateway prefix)',
+            );
+            assert.ok(
+                /hx-post="admin\/otel"/.test(r.raw),
+                'status page must call admin/otel via a relative path',
+            );
+            assert.ok(
+                /hx-post="admin\/log-level"/.test(r.raw),
+                'status page must call admin/log-level via a relative path',
+            );
+            assert.ok(
+                /hx-post="admin\/tcp"/.test(r.raw),
+                'status page must call admin/tcp via a relative path',
+            );
+            ok('status page uses relative admin paths in hx-post');
+
+            // (8c+d) form id + localStorage key references.
+            assert.ok(r.raw.includes('id="lmx-admin"'),
+                'status page should contain the admin form id');
+            assert.ok(r.raw.includes('lmx-admin-token'),
+                'status page should reference the localStorage key');
+            assert.ok(r.raw.includes('htmx:configRequest'),
+                'status page should attach a configRequest handler that injects the token');
+            assert.ok(r.raw.includes('meta http-equiv="refresh"'),
+                'status page should still auto-refresh');
+            ok('status page wires localStorage token into htmx requests');
+        }
+
+        // --- Log-level actually gates routineEnter stdout writes -----
+        {
+            const captured: string[] = [];
+            const origWrite = process.stdout.write.bind(process.stdout) as typeof process.stdout.write;
+            (process.stdout as any).write = (
+                chunk: any,
+                encoding?: any,
+                cb?: any,
+            ): boolean => {
+                try {
+                    const s = typeof chunk === 'string'
+                        ? chunk
+                        : Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+                    captured.push(s);
+                } catch { /* ignore */ }
+                if (typeof encoding === 'function') return (origWrite as any)(chunk, encoding);
+                return (origWrite as any)(chunk, encoding, cb);
+            };
+            try {
+                setLogLevel('silent');
+                captured.length = 0;
+                routineEnter('ddl-routine-test-silent-Aa1', 'admin-controls-test.silent');
+                const silentHits = captured.filter(s => s.includes('lmx routine:')).length;
+                assert.strictEqual(silentHits, 0, 'silent should suppress routineEnter stdout');
+
+                setLogLevel('info');
+                captured.length = 0;
+                routineEnter('ddl-routine-test-info-Bb2', 'admin-controls-test.info');
+                const infoHits = captured.filter(s => s.includes('lmx routine:')).length;
+                assert.ok(infoHits >= 1, 'info should allow routineEnter stdout');
+            } finally {
+                (process.stdout as any).write = origWrite;
+                setLogLevel('info');
+            }
+            ok('setLogLevel(silent) suppresses routineEnter stdout writes');
+        }
+
+        console.log('\n\u2705 admin-controls-test: all checks passed');
+    } finally {
+        await httpServer.stop();
+        broker.close(null);
+    }
+    clearTimeout(watchdog);
+    process.exit(0);
+}
+
+main().catch(err => {
+    console.error('FAIL:', err && err.stack || err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds runtime-toggleable operator controls (telemetry, log level, TCP NODELAY) to the broker's HTML status page, driven entirely by HTMX from the unpkg CDN. The broker continues to ship zero local JS/CSS assets.

- New `src/log-level.ts` module exposes `getLogLevel` / `setLogLevel` / `isLogLevelEnabled` with the hierarchy `silent < error < warn < info < debug < trace`. Default comes from `LMX_LOG_LEVEL` (`info` if unset). Used to gate the noisy `routineEnter` stdout writes so `silent` actually quiets the broker.
- New `Broker1.setNoDelay(boolean)` mutator. The connection-accept handler already reads `self.noDelay` per-connection, so new accepted sockets pick the new value up immediately; documented inline that the Rust broker owns `TCP_QUICKACK` while Node's `net.Socket` API only exposes `NODELAY`.
- Two new admin endpoints, both gated by the existing `checkAdminAuth` helper:
  - `GET/POST /admin/log-level` -> `{level}`
  - `GET/POST /admin/tcp` -> `{nodelay}`
- Admin POST handlers accept BOTH `application/json` and `application/x-www-form-urlencoded` (what HTMX sends). When the request carries `HX-Request: true` the response is a short HTML snippet (`level: <strong>warn</strong>`, `otel: <strong>on</strong>`, etc.) that HTMX swaps in place; plain JSON callers still get the original JSON shape - no behavior change for existing `/admin/otel` consumers.
- Status page gains an `Admin controls` section (`id="lmx-admin"`):
  - Loads HTMX from `https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js` with the SRI integrity hash pinned.
  - All `hx-post` URLs are RELATIVE (no leading slash) so the page works behind the `/lmx-node/` gateway prefix.
  - One small inline script persists the admin token under `localStorage['lmx-admin-token']` and injects it as `x-admin-token` on every htmx request via `htmx:configRequest`.

## Test plan

- [x] `npm run build` succeeds.
- [x] `npx ts-node test/admin-controls-test.ts` passes 15/15 assertions, including:
  - admin endpoints return HTML for `HX-Request`, JSON otherwise (both content-types exercised).
  - status page loads htmx from the pinned unpkg URL with the exact SRI hash.
  - status page uses relative `hx-post="admin/..."` paths (no leading slash).
  - `setLogLevel('silent')` regression check confirms `routineEnter` stdout is suppressed.
- [x] `npx ts-node test/admin-otel-toggle-test.ts` (existing regression suite) still passes 7/7.
- [x] Local smoke against the running broker on port 6971:
  - `/healthz` -> 200
  - `GET /admin/log-level` -> 200 `{"level":"info"}`
  - `POST /admin/log-level` (JSON) -> 200
  - `GET /admin/tcp` -> 200 `{"nodelay":true}`
  - HTMX-style `POST /admin/otel` (form + `HX-Request: true`) -> 200 `text/html` `otel: <strong>on</strong>`.

`package.json` version is intentionally unchanged - this is not an npm publish; the deployment builds from source.


Made with [Cursor](https://cursor.com)