### PR TITLE
fix(docker): switch USER to numeric UID so k8s runAsNonRoot passes (0.2.25-dd.2)

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -25,12 +25,12 @@
 #   docker buildx build \
 #     --platform linux/amd64 \
 #     --file Dockerfile.image \
-#     --tag docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.1 \
+#     --tag docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.2 \
 #     --push .
 #
 # Run:
 #   docker run --rm -p 6970:6970 -p 6971:6971 \
-#     docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.1
+#     docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.2
 
 FROM node:22-bookworm-slim AS build
 
@@ -63,12 +63,21 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 
-# `node:22-bookworm-slim` already ships uid/gid 1000 ("node").
-USER node
+# `node:22-bookworm-slim` ships the `node` account at uid/gid 1000.
+# We declare USER as a *numeric* UID:GID pair (not the string `node`)
+# because Kubernetes' `runAsNonRoot: true` admission check inspects the
+# OCI image config's `User` field at kubelet level WITHOUT resolving
+# `/etc/passwd` inside the image. With `USER node`, the kubelet refuses
+# to start the container ("container has runAsNonRoot and image has
+# non-numeric user (node), cannot verify user is non-root"), the
+# Service has zero endpoints, and the gateway returns 502. Numeric UID
+# satisfies the check unambiguously and matches the pattern the Rust
+# broker's Dockerfile uses (USER 65532:65532).
+USER 1000:1000
 
-COPY --from=build --chown=node:node /app/node_modules ./node_modules
-COPY --from=build --chown=node:node /app/dist          ./dist
-COPY --from=build --chown=node:node /app/package.json  ./package.json
+COPY --from=build --chown=1000:1000 /app/node_modules ./node_modules
+COPY --from=build --chown=1000:1000 /app/dist          ./dist
+COPY --from=build --chown=1000:1000 /app/package.json  ./package.json
 
 EXPOSE 6970 6971
 


### PR DESCRIPTION
## Summary

The 0.2.25-dd.1 image used \`USER node\` (string) in the runtime layer. \`node:22-bookworm-slim\`'s \`node\` account is uid:gid 1000:1000, but the OCI image config records the literal string \`node\`, not the resolved UID.

Kubernetes' \`runAsNonRoot: true\` admission check inspects the OCI image config's \`User\` field at the kubelet level and refuses to start the container if the value is a non-numeric username:

> container has runAsNonRoot and image has non-numeric user (node), cannot verify user is non-root

The Service has zero endpoints and \`dd-remote-gateway\` returns 502 on \`/lmx-node/\`. The image ran fine under \`docker run\` because Docker doesn't enforce that — only k8s does.

## Fix

- \`USER node\` -> \`USER 1000:1000\` (mirrors the Rust broker's \`USER 65532:65532\`).
- Runtime \`COPY --chown\` lines updated to match the numeric UID/GID.
- Image tag bumped to 0.2.25-dd.2; pushed: \`docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.2\` (linux/amd64).

## Verification (local)

- \`docker inspect\` reports \`Config.User=1000:1000\`.
- \`docker run --user 1000:1000\` runs cleanly; \`id\` inside the container reports \`uid=1000(node) gid=1000(node)\`.
- \`/healthz\` answers 200.

## Test plan

- [ ] Merge to \`dev\`.
- [ ] Bump cluster image tag in \`k8s-cluster\` from \`0.2.25-dd.1\` -> \`0.2.25-dd.2\` (separate parent PR).
- [ ] After ArgoCD reconciles, https://54.91.17.58/lmx-node/ should respond.

Made with [Cursor](https://cursor.com)