### PR TITLE
feat(bridge): harden VirtualSocket — full net.Socket surface, async callbacks, lifecycle ordering (0.2.25-dd.3)

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -25,12 +25,12 @@
 #   docker buildx build \
 #     --platform linux/amd64 \
 #     --file Dockerfile.image \
-#     --tag docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.2 \
+#     --tag docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.3 \
 #     --push .
 #
 # Run:
 #   docker run --rm -p 6970:6970 -p 6971:6971 \
-#     docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.2
+#     docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.3
 
 FROM node:22-bookworm-slim AS build
 

--- a/src/in-process-bridge.ts
+++ b/src/in-process-bridge.ts
@@ -59,94 +59,350 @@ type Pending = {
 };
 
 /**
- * Mock `net.Socket` that the broker can hold onto as an opaque
- * connection handle. We only implement the surface the broker
- * actually touches — see the call sites in `broker-1.ts`:
- * `ws.writable`, `ws.write(buf, enc, cb)`, `ws.lmxClosed`, plus
- * the no-op `destroy` / `end` / `removeAllListeners` cleanup hooks.
+ * In-process stand-in for `net.Socket` that the `Broker1` can treat
+ * as an ordinary connected peer. The broker's hot path types every
+ * connection as `LMXSocket extends net.Socket`, so this class has to
+ * present enough of that surface to behave faithfully under three
+ * orthogonal pressures:
  *
- * `pipe()` is implemented as a no-op identity because the broker's
- * connection handler calls `ws.pipe(createParser())` — but we never
- * route the bridge's virtual socket through `net.createServer`, so
- * `pipe` is never actually invoked. It's defined defensively so a
- * future refactor that does call it doesn't crash.
+ *   1. **Method/property surface** — every method the broker actually
+ *      calls and every property it actually reads must exist and behave
+ *      sensibly. Missing methods would crash; missing properties would
+ *      silently produce `undefined` and break invariants like
+ *      `if (!ws.writable)` checks.
+ *
+ *   2. **Async semantics** — real `net.Socket` callbacks (the `write`
+ *      cb, `'data'` events on the peer's read side, lifecycle events
+ *      like `'finish'`/`'end'`/`'close'`) **never** fire synchronously
+ *      inside the call that triggered them. The kernel/libuv always
+ *      interpose at least one tick. The previous implementation fired
+ *      `onFrame` synchronously inside `write()`, which meant the
+ *      bridge's awaiter could resume mid-broker-handler and observe
+ *      half-mutated broker state. Every callback below is dispatched
+ *      via `process.nextTick`, which is the closest faithful mimic of
+ *      "the data crossed the boundary."
+ *
+ *   3. **Lifecycle ordering** — `end()` must emit `'finish'` then
+ *      `'end'` then `'close'`; `destroy(err)` must emit `'error'`
+ *      (only when an Error was supplied) then `'close'`; both flows
+ *      must be idempotent. This matches the documented stream/socket
+ *      contract operators rely on when they wire `.once('end', …)`,
+ *      `.once('error', …)`, etc.
+ *
+ * This class does NOT pretend to fully implement `net.Socket` (there
+ * are dozens of internal `_writev`/`_write` hooks meant only for the
+ * stream subsystem). It implements the documented public surface plus
+ * the LMX-specific extension fields (`lmxClosed`, `destroyTimeout`)
+ * that `LMXSocket` adds. The `as unknown as LMXSocket` cast at the
+ * call site is the explicit acknowledgement that we're a structural
+ * subset, not a full subclass.
  */
-class VirtualSocket extends EventEmitter {
+const NEXT_TICK = process.nextTick;
+
+export class VirtualSocket extends EventEmitter {
+    // ---- net.Socket-mirroring state ---------------------------------
     public writable = true;
+    public readable = true;
+    public destroyed = false;
+    public connecting = false;
+    public pending = false;
+    public bufferSize = 0;
+    public bytesRead = 0;
+    public bytesWritten = 0;
+    public timeout = 0;
+    public allowHalfOpen = false;
+    public localAddress = 'inproc';
+    public localPort = 0;
+    public remoteAddress = 'inproc';
+    public remoteFamily: 'IPv4' | 'IPv6' = 'IPv4';
+    public remotePort = 0;
+
+    // ---- LMXSocket extensions ---------------------------------------
     public lmxClosed = false;
-    public destroyTimeout: NodeJS.Timeout | undefined;
+    public destroyTimeout: NodeJS.Timeout | undefined = undefined;
+
+    // ---- internals --------------------------------------------------
+    private finishEmitted = false;
+    private endEmitted = false;
+    private closeEmitted = false;
 
     constructor(private readonly onFrame: (frame: any) => void) {
+        super();
         const routineId = 'ddl-routine-WoFE6z7qO40Cz1uHkd';
         routineEnter(routineId, "VirtualSocket.constructor");
-        super();
-        // The broker registers many listeners; lift the warning ceiling
-        // so multi-listener flows don't pollute logs. 256 is well above
-        // the per-connection listener count the broker installs (< 8).
+        // The broker installs ~6 listeners per accepted socket and
+        // also subscribes from the parser side. 256 is generous for
+        // any plausible future addition without spamming
+        // MaxListenersExceededWarning into stderr.
         this.setMaxListeners(256);
     }
 
-    /// Capture the broker's reply. The wire framing matches the TCP
-    /// path: one or more newline-terminated JSON objects per write.
-    /// We forward each parsed object to the bridge's correlation map.
-    write(data: string | Buffer, encoding?: any, cb?: any): boolean {
+    /**
+     * `readyState` mirrors `net.Socket.readyState` for any operator
+     * code (or a future debugger) that introspects the socket.
+     */
+    get readyState(): 'open' | 'readOnly' | 'writeOnly' | 'closed' | 'opening' {
+        if (this.destroyed) return 'closed';
+        if (this.writable && this.readable) return 'open';
+        if (this.writable) return 'writeOnly';
+        if (this.readable) return 'readOnly';
+        return 'closed';
+    }
+
+    /**
+     * Accept the broker's reply frames and forward them to the bridge.
+     *
+     * The broker always writes exactly one newline-terminated JSON
+     * object per call (`JSON.stringify(data) + '\n'`). We split on
+     * newline anyway as future-proofing.
+     *
+     * Async-correctness: BOTH the `onFrame` callback AND the write
+     * callback are scheduled via `process.nextTick`. The previous
+     * implementation called `onFrame` synchronously inside `write()`,
+     * which meant the bridge's awaiter could resume *during* the
+     * broker's send call and observe state the broker hadn't yet
+     * finished mutating. Real `net.Socket` always crosses at least
+     * one event-loop tick between sender's `write()` and receiver's
+     * `'data'` event; this implementation does the same.
+     */
+    write(
+        data: string | Buffer | Uint8Array,
+        encoding?: BufferEncoding | ((err?: Error | null) => void),
+        cb?: (err?: Error | null) => void
+    ): boolean {
         const routineId = 'ddl-routine-bJjgk0J2Y3jw4yPBC7';
         routineEnter(routineId, "VirtualSocket.write");
-        const text = typeof data === 'string' ? data : data.toString('utf8');
-        // The broker always writes exactly one frame at a time
-        // (`JSON.stringify(data) + '\n'`), but split-on-newline is the
-        // robust choice — defends against any future change.
+
+        // net.Socket accepts (data), (data, encoding), (data, cb),
+        // and (data, encoding, cb). Normalize to a single callback.
+        const callback: ((err?: Error | null) => void) | undefined =
+            typeof encoding === 'function' ? encoding : cb;
+        const enc: BufferEncoding =
+            typeof encoding === 'string' ? encoding : 'utf8';
+
+        if (this.destroyed || !this.writable) {
+            const err = Object.assign(
+                new Error('Cannot call write after a stream was destroyed'),
+                {code: 'ERR_STREAM_DESTROYED'},
+            );
+            if (callback) NEXT_TICK(callback, err);
+            return false;
+        }
+
+        let buf: Buffer;
+        if (typeof data === 'string') {
+            buf = Buffer.from(data, enc);
+        } else if (Buffer.isBuffer(data)) {
+            buf = data;
+        } else if (data instanceof Uint8Array) {
+            buf = Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+        } else {
+            const err = new TypeError(
+                `VirtualSocket.write: unsupported data type ${typeof data}`,
+            );
+            if (callback) NEXT_TICK(callback, err);
+            return false;
+        }
+
+        this.bytesWritten += buf.byteLength;
+        const text = buf.toString('utf8');
+
         for (const line of text.split('\n')) {
             if (line.length === 0) continue;
+            let frame: any;
             try {
-                const frame = JSON.parse(line);
-                this.onFrame(frame);
+                frame = JSON.parse(line);
             } catch {
-                // Drop malformed frames silently — the TCP path also
-                // emits a 'warning' here; we don't have a place to
-                // surface that and it would only fire on a bug.
+                // Match the TCP path: malformed frames are dropped.
+                // (The real socket path emits a 'warning' here, but
+                // we have no plumbing to surface it from a write call
+                // and the bridge protocol is internal — a malformed
+                // frame would be a bug, not a client misbehavior.)
+                continue;
             }
+            this.bytesRead += line.length + 1;
+            const captured = frame;
+            // FIFO order across frames is preserved because
+            // process.nextTick is a queue.
+            NEXT_TICK(() => {
+                if (this.destroyed) return;
+                try {
+                    this.onFrame(captured);
+                } catch (err) {
+                    this.emit('error', err);
+                }
+            });
         }
-        // The TCP `send` path uses a `(err) => {...; cb && process.nextTick(cb)}`
-        // shape. Honour both call-styles (encoding+cb, or just cb).
-        const callback = typeof encoding === 'function' ? encoding : cb;
-        if (typeof callback === 'function') {
-            process.nextTick(callback);
-        }
+
+        if (callback) NEXT_TICK(callback, null);
         return true;
     }
 
-    setNoDelay(_value: boolean): void {
-      const routineId = 'ddl-routine-Vrs-ZEZMgsE_Dg8ajg';
-      routineEnter(routineId, "VirtualSocket.setNoDelay");
-        // No-op; the broker calls this defensively in its TCP path.
-    }
-
-    destroy(): void {
-        const routineId = 'ddl-routine-BWbtmhL8y5oFTERAvH';
-        routineEnter(routineId, "VirtualSocket.destroy");
-        if (this.lmxClosed) return;
-        this.lmxClosed = true;
-        this.writable = false;
-        this.emit('end');
-    }
-
-    end(): void {
+    /**
+     * Half-close the write side. Real `net.Socket.end()` sequence:
+     *   - flush any pending writes
+     *   - emit `'finish'` (write side fully drained)
+     *   - peer FIN-ACK arrives → emit `'end'`
+     *   - resources released → emit `'close'`
+     *
+     * For our virtual socket there's no peer to FIN-ACK, so we
+     * synthesize all three on `nextTick` in the documented order.
+     * Idempotent: a second `end()` is a no-op.
+     */
+    end(
+        data?: any,
+        encoding?: BufferEncoding | (() => void),
+        cb?: () => void,
+    ): this {
         const routineId = 'ddl-routine-tCwQ_9Cia5ybFRg5-r';
         routineEnter(routineId, "VirtualSocket.end");
-        this.destroy();
+
+        // net.Socket.end signatures: (), (data), (data, encoding),
+        // (data, encoding, cb), (cb), (data, cb).
+        let endCb: (() => void) | undefined;
+        let payload: any = data;
+        let enc: BufferEncoding | undefined;
+        if (typeof data === 'function') {
+            endCb = data as () => void;
+            payload = undefined;
+        } else if (typeof encoding === 'function') {
+            endCb = encoding as () => void;
+        } else {
+            enc = encoding as BufferEncoding | undefined;
+            endCb = cb;
+        }
+
+        if (this.destroyed) {
+            if (endCb) NEXT_TICK(endCb);
+            return this;
+        }
+
+        const finalize = () => {
+            if (!this.writable) return; // re-entrancy guard
+            this.writable = false;
+            if (!this.finishEmitted) {
+                this.finishEmitted = true;
+                this.emit('finish');
+            }
+            if (!this.endEmitted) {
+                this.endEmitted = true;
+                this.emit('end');
+            }
+            // 'close' lands one tick later, mirroring net.Socket.
+            NEXT_TICK(() => {
+                this.readable = false;
+                this.destroyed = true;
+                this.lmxClosed = true;
+                if (!this.closeEmitted) {
+                    this.closeEmitted = true;
+                    this.emit('close', false);
+                }
+                if (endCb) endCb();
+            });
+        };
+
+        if (payload !== undefined) {
+            // Drain the trailing payload through write() so its
+            // bytes count toward bytesWritten and any frames it
+            // contains reach the bridge before close.
+            this.write(payload, enc as any, () => NEXT_TICK(finalize));
+        } else {
+            NEXT_TICK(finalize);
+        }
+        return this;
     }
+
+    /**
+     * Abrupt close. Idempotent. Emits `'error'` (if an Error was
+     * supplied) then `'close'` on the next tick. After `destroy()`,
+     * `write()` returns false with `ERR_STREAM_DESTROYED` on the cb.
+     */
+    destroy(err?: Error | null): this {
+        const routineId = 'ddl-routine-BWbtmhL8y5oFTERAvH';
+        routineEnter(routineId, "VirtualSocket.destroy");
+        if (this.destroyed) return this;
+        this.writable = false;
+        this.readable = false;
+        this.destroyed = true;
+        this.lmxClosed = true;
+        NEXT_TICK(() => {
+            if (err) this.emit('error', err);
+            if (!this.closeEmitted) {
+                this.closeEmitted = true;
+                this.emit('close', !!err);
+            }
+        });
+        return this;
+    }
+
+    /// `address()` is what `net.Server` connection callbacks read on
+    /// every accepted socket. We return the same shape so future
+    /// introspection code doesn't crash on `.address().port`.
+    address(): {address: string, family: string, port: number} {
+        return {address: this.localAddress, family: this.remoteFamily, port: this.localPort};
+    }
+
+    /**
+     * The broker calls `pipe(createParser())` on accepted sockets so
+     * inbound bytes flow through the NDJSON parser. The bridge never
+     * goes through that path — inbound traffic is delivered via
+     * direct method calls (`broker.lock(payload, virtualSocket)`).
+     * `pipe` is an identity no-op so any future code that does call
+     * it doesn't crash, and so `ws.pipe(parser).on('data', …)` still
+     * lets the caller subscribe to the parser they passed in.
+     */
+    pipe<T>(target: T): T {
+        const routineId = 'ddl-routine-UW5cpE6tXO9q0ekt-Z';
+        routineEnter(routineId, "VirtualSocket.pipe");
+        return target;
+    }
+
+    unpipe(_target?: any): this {
+        return this;
+    }
+
+    // ---- chainable no-op tuning methods -----------------------------
+    // All of these exist on net.Socket and are called defensively by
+    // socket-tuning code. None of them have a meaningful in-process
+    // analogue. They return `this` to preserve the documented
+    // chainable signature so `socket.setNoDelay(true).setKeepAlive(...)`
+    // patterns survive.
+
+    setNoDelay(_value?: boolean): this {
+        const routineId = 'ddl-routine-Vrs-ZEZMgsE_Dg8ajg';
+        routineEnter(routineId, "VirtualSocket.setNoDelay");
+        return this;
+    }
+
+    setKeepAlive(_enable?: boolean, _initialDelay?: number): this {
+        return this;
+    }
+
+    setTimeout(timeout: number, callback?: () => void): this {
+        // Capture the requested timeout so debug/observation code can
+        // read it back; we don't actually fire 'timeout' on idle since
+        // there's no real I/O to time out. If a caller needs that
+        // behavior they can install the listener directly.
+        this.timeout = timeout;
+        if (callback) this.once('timeout', callback);
+        return this;
+    }
+
+    setEncoding(_encoding?: BufferEncoding): this {
+        return this;
+    }
+
+    unref(): this { return this; }
+    ref(): this { return this; }
+    pause(): this { return this; }
+    resume(): this { return this; }
+    cork(): void { /* noop */ }
+    uncork(): void { /* noop */ }
 
     removeAllListeners(event?: string | symbol): this {
         const routineId = 'ddl-routine-7swZayhZQfvHIFSgKh';
         routineEnter(routineId, "VirtualSocket.removeAllListeners");
         return super.removeAllListeners(event);
-    }
-
-    pipe<T>(target: T): T {
-        const routineId = 'ddl-routine-UW5cpE6tXO9q0ekt-Z';
-        routineEnter(routineId, "VirtualSocket.pipe");
-        return target;
     }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ export {Client, LMXClient, LvMtxClient} from './client';
 export {Broker, LMXBroker, LvMtxBroker} from './broker';
 export {Broker1, LMXBroker as LMXBroker1, LvMtxBroker as LvMtxBroker1} from './broker-1';
 export {LMXHttpServer} from './http-server';
-export {InProcessBridge} from './in-process-bridge';
+export {InProcessBridge, VirtualSocket} from './in-process-bridge';
 export {routineEnter, initOtel, shutdownOtel, setOtelEnabled, isOtelEnabled} from './routine';
 export {getLogLevel, setLogLevel, isLogLevelEnabled, LMX_LOG_LEVELS} from './log-level';
 export type {LMXLogLevel} from './log-level';

--- a/test/virtual-socket-test.ts
+++ b/test/virtual-socket-test.ts
@@ -1,0 +1,392 @@
+'use strict';
+
+/**
+ * Lifecycle + async-semantics regression tests for `VirtualSocket`,
+ * the in-process stand-in for `net.Socket` that backs every
+ * `InProcessBridge`.
+ *
+ * The previous implementation called `onFrame` *synchronously* inside
+ * `write()`. That meant the bridge's awaiter could resume mid-broker
+ * handler and observe state the broker hadn't finished mutating. Real
+ * `net.Socket` always crosses at least one tick between sender's
+ * `write()` and receiver's `'data'` event; this suite locks in that
+ * we now do the same, and also pins down the documented
+ * lifecycle-ordering contract (`finish` -> `end` -> `close` for
+ * `end()`; `error` -> `close` for `destroy(err)`; both flows
+ * idempotent).
+ *
+ * Asserts:
+ *   1. `write()` schedules `onFrame` on a future tick — never
+ *      synchronously inside the same call.
+ *   2. Multiple frames in one buffer arrive at `onFrame` in FIFO
+ *      order on the next tick.
+ *   3. `bytesWritten` and `bytesRead` track byte counts.
+ *   4. `write()` after `destroy()` returns `false` and fires the
+ *      callback with `ERR_STREAM_DESTROYED` on `nextTick`.
+ *   5. `write()` accepts `string | Buffer | Uint8Array`.
+ *   6. `destroy()` is idempotent (a second call is a no-op and does
+ *      NOT re-emit `'close'`).
+ *   7. `destroy(err)` emits `'error'` THEN `'close'(true)` on
+ *      `nextTick`.
+ *   8. `end()` emits `'finish'` -> `'end'` -> `'close'(false)` in
+ *      that order.
+ *   9. `end()` is idempotent.
+ *  10. `address()` returns a `net.Server`-compatible shape.
+ *  11. `readyState` transitions through `open` -> `closed` cleanly.
+ *  12. Tuning no-ops (`setNoDelay`, `setKeepAlive`, `setTimeout`,
+ *      `setEncoding`, `unref`, `ref`, `pause`, `resume`) return
+ *      `this` (chainable, like real net.Socket).
+ *  13. `pipe(target)` returns `target` so
+ *      `ws.pipe(parser).on('data', cb)` keeps working.
+ *  14. The LMXSocket extension fields (`lmxClosed`, `destroyTimeout`)
+ *      exist with the right initial values.
+ *  15. End-to-end through the bridge: `await bridge.lock(...)`
+ *      resolves only AFTER the broker's lock-handler has fully
+ *      returned (proves the awaiter never observes mid-handler state).
+ *
+ * Self-times-out at 8s. Any hang means a callback didn't fire or a
+ * lifecycle event went missing.
+ */
+
+import * as assert from 'assert';
+import {Broker1, InProcessBridge, VirtualSocket} from '../dist/main';
+
+function fail(msg: string): never {
+    console.error('\u274c FAIL:', msg);
+    process.exit(1);
+}
+
+function ok(msg: string) {
+    console.log('  \u2713', msg);
+}
+
+const watchdog = setTimeout(() => {
+    console.error('\u274c TIMEOUT: virtual-socket-test took too long');
+    process.exit(1);
+}, 8_000);
+watchdog.unref();
+
+function nextTick(): Promise<void> {
+    return new Promise(r => process.nextTick(r));
+}
+
+function tickTwice(): Promise<void> {
+    return new Promise(r => process.nextTick(() => process.nextTick(r)));
+}
+
+async function main() {
+    // ===========================================================
+    // [1] write() schedules onFrame on a future tick (NOT sync)
+    // ===========================================================
+    console.log('[1] onFrame is async — never fires inside write()');
+    {
+        const frames: any[] = [];
+        const sock = new VirtualSocket(f => frames.push(f));
+        const writeReturned = sock.write('{"a":1}\n');
+        if (writeReturned !== true) fail(`write should return true; got ${writeReturned}`);
+        const lenBeforeTick = frames.length;
+        if (lenBeforeTick !== 0) {
+            fail(`onFrame fired synchronously inside write() — saw ${lenBeforeTick} frames`);
+        }
+        await nextTick();
+        const lenAfterTick = frames.length;
+        if (lenAfterTick !== 1) fail(`expected 1 frame after one tick; got ${lenAfterTick}`);
+        if (frames[0].a !== 1) fail(`bad frame payload: ${JSON.stringify(frames[0])}`);
+        ok('onFrame deferred to next tick (not sync)');
+    }
+
+    // ===========================================================
+    // [2] Multiple frames in one buffer arrive in FIFO order
+    // ===========================================================
+    console.log('\n[2] multiple frames arrive in FIFO order on next tick');
+    {
+        const frames: any[] = [];
+        const sock = new VirtualSocket(f => frames.push(f));
+        sock.write('{"i":0}\n{"i":1}\n{"i":2}\n');
+        const lenBefore = frames.length;
+        if (lenBefore !== 0) fail('frames delivered synchronously');
+        await tickTwice();
+        const lenAfter = frames.length;
+        if (lenAfter !== 3) fail(`expected 3 frames; got ${lenAfter}`);
+        for (let i = 0; i < 3; i++) {
+            if (frames[i].i !== i) fail(`frame order broken at ${i}: ${JSON.stringify(frames)}`);
+        }
+        ok(`3 frames arrived in order: ${frames.map(f => f.i).join(',')}`);
+    }
+
+    // ===========================================================
+    // [3] bytesWritten / bytesRead are tracked
+    // ===========================================================
+    console.log('\n[3] bytes counters track byte counts');
+    {
+        const sock = new VirtualSocket(() => {});
+        const a = '{"x":1}\n';
+        const b = '{"y":2}\n';
+        sock.write(a);
+        sock.write(Buffer.from(b, 'utf8'));
+        if (sock.bytesWritten !== Buffer.byteLength(a) + Buffer.byteLength(b)) {
+            fail(`bytesWritten=${sock.bytesWritten}, expected ${Buffer.byteLength(a) + Buffer.byteLength(b)}`);
+        }
+        await tickTwice();
+        // bytesRead counts each delivered frame's parsed line.length + 1 (newline).
+        if (sock.bytesRead === 0) fail('bytesRead never incremented');
+        ok(`bytesWritten=${sock.bytesWritten}, bytesRead=${sock.bytesRead}`);
+    }
+
+    // ===========================================================
+    // [4] write() after destroy() returns false + cb gets err
+    // ===========================================================
+    console.log('\n[4] write() after destroy() rejects with ERR_STREAM_DESTROYED');
+    {
+        const sock = new VirtualSocket(() => {});
+        sock.destroy();
+        let cbErr: any = 'NOT-CALLED';
+        const ret = sock.write('{"a":1}\n', 'utf8', err => { cbErr = err; });
+        if (ret !== false) fail(`write after destroy should return false; got ${ret}`);
+        await nextTick();
+        if (!cbErr || cbErr === 'NOT-CALLED') fail('write callback was not invoked after destroy');
+        if ((cbErr as any).code !== 'ERR_STREAM_DESTROYED') {
+            fail(`expected ERR_STREAM_DESTROYED, got code=${(cbErr as any).code} msg=${(cbErr as any).message}`);
+        }
+        ok(`got ${cbErr.code}: ${cbErr.message}`);
+    }
+
+    // ===========================================================
+    // [5] write() accepts string | Buffer | Uint8Array
+    // ===========================================================
+    console.log('\n[5] write() accepts string, Buffer, and Uint8Array');
+    {
+        const frames: any[] = [];
+        const sock = new VirtualSocket(f => frames.push(f));
+        sock.write('{"src":"string"}\n');
+        sock.write(Buffer.from('{"src":"buffer"}\n', 'utf8'));
+        // Plain Uint8Array (NOT a Buffer) to exercise the third branch.
+        const u8src = '{"src":"u8"}\n';
+        const u8 = new Uint8Array(Buffer.byteLength(u8src));
+        for (let i = 0; i < u8src.length; i++) u8[i] = u8src.charCodeAt(i);
+        sock.write(u8);
+        await tickTwice();
+        const sources = frames.map(f => f.src).sort();
+        assert.deepStrictEqual(sources, ['buffer', 'string', 'u8']);
+        ok(`got 3 frames from 3 input shapes: ${sources.join(',')}`);
+    }
+
+    // ===========================================================
+    // [6] destroy() is idempotent — second call is a no-op
+    // ===========================================================
+    console.log('\n[6] destroy() is idempotent');
+    {
+        const sock = new VirtualSocket(() => {});
+        let closeCount = 0;
+        sock.on('close', () => { closeCount++; });
+        sock.destroy();
+        sock.destroy(); // second call must NOT re-emit close
+        await tickTwice();
+        const observed = closeCount;
+        if (observed !== 1) fail(`expected 1 close emit; got ${observed}`);
+        if (!sock.destroyed) fail('destroyed flag not set');
+        if (sock.writable !== false) fail('writable should be false after destroy');
+        if (sock.readable !== false) fail('readable should be false after destroy');
+        if (sock.lmxClosed !== true) fail('lmxClosed should be true (LMX-extension contract)');
+        ok('second destroy() was a no-op; close fired exactly once');
+    }
+
+    // ===========================================================
+    // [7] destroy(err) emits error THEN close(true) on nextTick
+    // ===========================================================
+    console.log('\n[7] destroy(err) emits error -> close(true) async');
+    {
+        const sock = new VirtualSocket(() => {});
+        const events: Array<{name: string, payload?: any}> = [];
+        sock.on('error', e => events.push({name: 'error', payload: e}));
+        sock.on('close', hadError => events.push({name: 'close', payload: hadError}));
+        const myErr = new Error('boom');
+        sock.destroy(myErr);
+        // SYNC observation: nothing emitted yet.
+        const beforeLen = events.length;
+        if (beforeLen !== 0) fail(`events fired sync inside destroy(): ${JSON.stringify(events)}`);
+        await nextTick();
+        const afterLen = events.length;
+        if (afterLen !== 2) fail(`expected 2 events; got ${afterLen}: ${events.map(e => e.name).join(',')}`);
+        if (events[0].name !== 'error') fail(`first event should be error; got ${events[0].name}`);
+        if (events[0].payload !== myErr) fail('error event did not carry the supplied Error instance');
+        if (events[1].name !== 'close') fail(`second event should be close; got ${events[1].name}`);
+        if (events[1].payload !== true) fail(`close hadError should be true; got ${events[1].payload}`);
+        ok('error -> close(true) order preserved');
+    }
+
+    // ===========================================================
+    // [8] end() emits finish -> end -> close(false) in order
+    // ===========================================================
+    console.log('\n[8] end() emits finish -> end -> close(false) in order');
+    {
+        const sock = new VirtualSocket(() => {});
+        const events: string[] = [];
+        sock.on('finish', () => events.push('finish'));
+        sock.on('end', () => events.push('end'));
+        sock.on('close', hadError => events.push(`close(${hadError})`));
+        sock.end();
+        const lenA = events.length;
+        if (lenA !== 0) fail(`end() emitted events synchronously: ${events}`);
+        // Wait enough ticks for finalize (2 nextTicks: finalize body + close).
+        await tickTwice();
+        await nextTick();
+        const lenB = events.length;
+        if (lenB !== 3) fail(`expected 3 events; got ${lenB}: ${events}`);
+        assert.deepStrictEqual(events, ['finish', 'end', 'close(false)'],
+            `expected lifecycle order; got ${JSON.stringify(events)}`);
+        ok(`got ${events.join(' -> ')}`);
+    }
+
+    // ===========================================================
+    // [9] end() is idempotent
+    // ===========================================================
+    console.log('\n[9] end() is idempotent');
+    {
+        const sock = new VirtualSocket(() => {});
+        let closeCount = 0;
+        let finishCount = 0;
+        sock.on('finish', () => finishCount++);
+        sock.on('close', () => closeCount++);
+        sock.end();
+        sock.end();   // second end() must not re-fire finish/close
+        sock.end();   // third end() either
+        await tickTwice();
+        await nextTick();
+        if (finishCount !== 1) fail(`finish fired ${finishCount} times`);
+        if (closeCount !== 1) fail(`close fired ${closeCount} times`);
+        ok('finish + close each fired exactly once across 3 end() calls');
+    }
+
+    // ===========================================================
+    // [10] address() shape
+    // ===========================================================
+    console.log('\n[10] address() returns net.Socket-compatible shape');
+    {
+        const sock = new VirtualSocket(() => {});
+        const a = sock.address();
+        if (typeof a.address !== 'string') fail('address.address must be string');
+        if (typeof a.family !== 'string') fail('address.family must be string');
+        if (typeof a.port !== 'number') fail('address.port must be number');
+        ok(`address()=${JSON.stringify(a)}`);
+    }
+
+    // ===========================================================
+    // [11] readyState transitions
+    // ===========================================================
+    console.log('\n[11] readyState transitions cleanly');
+    {
+        const sock = new VirtualSocket(() => {});
+        const initial: string = sock.readyState;
+        if (initial !== 'open') fail(`initial readyState: ${initial}`);
+        sock.destroy();
+        const final: string = sock.readyState;
+        if (final !== 'closed') fail(`post-destroy readyState: ${final}`);
+        ok('open -> closed');
+    }
+
+    // ===========================================================
+    // [12] Tuning no-ops are chainable (return this)
+    // ===========================================================
+    console.log('\n[12] tuning no-ops are chainable (mirror net.Socket)');
+    {
+        const sock = new VirtualSocket(() => {});
+        const r1 = sock.setNoDelay(true);
+        const r2 = sock.setKeepAlive(true, 1000);
+        const r3 = sock.setTimeout(5000);
+        const r4 = sock.setEncoding('utf8');
+        const r5 = sock.unref();
+        const r6 = sock.ref();
+        const r7 = sock.pause();
+        const r8 = sock.resume();
+        for (const [name, ret] of [
+            ['setNoDelay', r1], ['setKeepAlive', r2], ['setTimeout', r3],
+            ['setEncoding', r4], ['unref', r5], ['ref', r6],
+            ['pause', r7], ['resume', r8],
+        ] as const) {
+            if (ret !== sock) fail(`${name}() should return this; got ${ret}`);
+        }
+        if (sock.timeout !== 5000) fail(`setTimeout did not capture value; got ${sock.timeout}`);
+        ok('all 8 tuning methods returned this; setTimeout captured value');
+    }
+
+    // ===========================================================
+    // [13] pipe(target) returns target
+    // ===========================================================
+    console.log('\n[13] pipe(target) returns target');
+    {
+        const sock = new VirtualSocket(() => {});
+        const fakeParser = {parserId: 'p1'};
+        const out = sock.pipe(fakeParser);
+        if (out !== fakeParser) fail('pipe did not return its argument');
+        ok('pipe returns its target so .pipe(parser).on(...) chaining works');
+    }
+
+    // ===========================================================
+    // [14] LMX extension fields exist with right initial values
+    // ===========================================================
+    console.log('\n[14] LMX extension fields are present');
+    {
+        const sock = new VirtualSocket(() => {});
+        if (sock.lmxClosed !== false) fail(`lmxClosed initial: ${sock.lmxClosed}`);
+        if (typeof sock.destroyTimeout !== 'undefined') fail(`destroyTimeout initial: ${sock.destroyTimeout}`);
+        // Broker code mutates these.
+        sock.destroyTimeout = setTimeout(() => {}, 60_000) as any;
+        sock.destroyTimeout && clearTimeout(sock.destroyTimeout);
+        ok('lmxClosed=false, destroyTimeout=undefined; both writable');
+    }
+
+    // ===========================================================
+    // [15] End-to-end through the bridge: await resolves only AFTER
+    //      the broker's lock-handler has fully returned. This proves
+    //      the async-onFrame fix prevents mid-handler observations.
+    // ===========================================================
+    console.log('\n[15] bridge awaiter resumes only after broker handler returns');
+    {
+        const broker = new Broker1({noListen: true, port: 0, host: '127.0.0.1'});
+        broker.emitter.on('warning', () => {});
+
+        const bridge = new InProcessBridge(broker);
+
+        // Sentinel: monkey-patch broker.lock to set a flag AFTER it
+        // finishes its synchronous bookkeeping. If the awaiter ever
+        // resumes before the flag is set, we know onFrame fired
+        // synchronously inside the broker's send call.
+        const realLock = broker.lock.bind(broker);
+        let handlerFinished = false;
+        let observedAtAwaiter: boolean | null = null;
+        (broker as any).lock = (payload: any, ws: any) => {
+            handlerFinished = false;
+            const r = realLock(payload, ws);
+            handlerFinished = true;
+            return r;
+        };
+
+        // Race the awaiter against the handler-finished flag.
+        const p = bridge.lock({key: 'sentinel', ttl: 5_000}).then((reply: any) => {
+            observedAtAwaiter = handlerFinished;
+            return reply;
+        });
+
+        const reply: any = await p;
+        if (reply.acquired !== true) fail(`expected acquired:true, got ${JSON.stringify(reply)}`);
+        if (observedAtAwaiter !== true) {
+            fail(`bridge awaiter resumed BEFORE broker.lock fully returned (handlerFinished=${observedAtAwaiter})`);
+        }
+        ok('awaiter observed handlerFinished=true (no mid-handler observation)');
+
+        // Sanity: bridge ownership cleanup still works.
+        await bridge.unlock({key: 'sentinel', lockUuid: reply._bridgeRequestUuid});
+        bridge.shutdown();
+        await new Promise<void>(r => broker.close(() => r()));
+    }
+
+    clearTimeout(watchdog);
+    console.log('\n\u2705 virtual-socket-test: all 15 checks passed');
+    process.exit(0);
+}
+
+main().catch(err => {
+    console.error('virtual-socket-test threw:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Hardens the `InProcessBridge`'s `VirtualSocket` so it behaves faithfully where the broker treats it as a real `net.Socket`.

Three classes of latent bug fixed:

1. **Sync \`onFrame\` inside \`write()\`.** The previous impl resolved the bridge's awaiter Promise *during* the broker's send call, so the awaiter could observe broker state before the handler had finished mutating it. Real \`net.Socket\` always crosses at least one event-loop tick — we now do the same via \`process.nextTick\`.
2. **Missing prop/method surface.** \`destroyed\`, \`readable\`, \`bytesRead\`, \`bytesWritten\`, \`address()\`, \`setKeepAlive\`, \`setEncoding\`, \`unref\`/\`ref\`, \`pause\`/\`resume\`, \`cork\`/\`uncork\`, \`unpipe\`, \`readyState\` were all missing. Now implemented as faithful no-ops (chainable where \`net.Socket\` is) or state mirrors.
3. **Wrong lifecycle event ordering.** \`end()\` now emits \`finish\` -> \`end\` -> \`close(false)\`; \`destroy(err)\` emits \`error\` (when err) -> \`close(!!err)\`; both flows idempotent and async, matching the documented socket contract.

Also:
- \`write()\` accepts \`string | Buffer | Uint8Array\` (real signature).
- \`write()\` after \`destroy()\` returns \`false\` + cb gets \`Error{code: 'ERR_STREAM_DESTROYED'}\`.
- \`bytesRead\` / \`bytesWritten\` track byte counts.

\`VirtualSocket\` is now \`export\`ed (re-exported from \`main.ts\`) so tests can target it directly. Still a structural subset of \`net.Socket\`, not a full subclass — the \`as unknown as LMXSocket\` cast at the call site is the explicit acknowledgement of that.

## New tests (\`test/virtual-socket-test.ts\`, 15 scenarios)

1. \`onFrame\` async (never sync inside \`write()\`)
2. FIFO frame order across one buffer
3. Bytes counters track byte counts
4. \`write()\` after \`destroy()\` -> \`ERR_STREAM_DESTROYED\`
5. \`write()\` accepts string / Buffer / Uint8Array
6. \`destroy()\` idempotent
7. \`destroy(err)\` -> error -> close(true)
8. \`end()\` -> finish -> end -> close(false)
9. \`end()\` idempotent
10. \`address()\` shape
11. \`readyState\` transitions
12. Tuning no-ops chainable
13. \`pipe(target)\` returns target
14. LMX extension fields present
15. End-to-end bridge race-test: awaiter never resumes mid-broker-handler

Existing \`test/in-process-bridge-test.ts\` and the admin-controls / admin-otel-toggle suites still pass.

## Image

\`docker.io/oresoftware/live-mutex-submodule:0.2.25-dd.3\` (linux/amd64). Local smoke: container runs as UID 1000, \`/healthz\` 200, \`/v1/stats\` reports \`connectedClients: 1\` (the bridge — expected), \`/v1/lock\` round-trips through the hardened bridge.

## Test plan

- [ ] Bump cluster image tag in \`k8s-cluster\` from \`0.2.25-dd.2\` -> \`0.2.25-dd.3\` (separate parent PR).
- [ ] After ArgoCD reconciles, https://54.91.17.58/lmx-node/ continues to serve the status page; \`/v1/stats\` continues to answer; lock round-trip works.

Made with [Cursor](https://cursor.com)