### PR TITLE
test(virtual-socket): expand coverage to 23 cases + add 800-op stress test

### DIFF
--- a/test/virtual-socket-stress-test.ts
+++ b/test/virtual-socket-stress-test.ts
@@ -1,0 +1,227 @@
+'use strict';
+
+/**
+ * High-concurrency stress test for the InProcessBridge + hardened
+ * VirtualSocket. The bridge correlation map (`inflight: Map<uuid,
+ * Pending>`) is the only thing keeping concurrent HTTP requests from
+ * stepping on each other's replies. If the FIFO `process.nextTick`
+ * delivery, the per-uuid resolution path, the bridge-ownership
+ * cleanup, or the Promise correlation map ever broke under load,
+ * this test would hang, reject, or yield wrong fencing-token order.
+ *
+ * What it does
+ * ------------
+ *
+ * Uses a `noListen` `Broker1` (no TCP listener at all) plus a single
+ * `InProcessBridge`, then drives every shape of bridge call in
+ * parallel:
+ *
+ *   * 200 concurrent `bridge.lock(...)` on distinct keys (each
+ *     should see its own grant + a unique fencing token).
+ *   * 200 concurrent `bridge.acquireMany(...)` requests on
+ *     three-key tuples (each gets a single composite lockUuid +
+ *     three fencing tokens).
+ *   * 200 concurrent `bridge.unlock(...)` matched against the
+ *     200 grants from step 1 (each releases its own hold, no
+ *     other lock affected).
+ *   * 200 concurrent `bridge.releaseMany(...)` matched against
+ *     the 200 composite holds.
+ *
+ * After every batch we assert:
+ *   * The bridge's `connectedClients` count never grew (still 1).
+ *   * `pendingCount` returned to 0.
+ *   * Broker `connectedClients.size` returned to baseline + 1
+ *     (just the bridge socket).
+ *   * Held-lock count matches the expected number of in-flight
+ *     holds.
+ *   * Heap usage stayed within a reasonable bound (no per-call
+ *     leak in the correlation map or the broker's wsToKeys/
+ *     wsToUUIDs maps).
+ *
+ * Self-times-out at 20s. On a current-gen MBP this typically
+ * finishes in 200-400ms.
+ */
+
+import * as assert from 'assert';
+import {Broker1, InProcessBridge} from '../dist/main';
+
+function fail(msg: string): never {
+    console.error('\u274c FAIL:', msg);
+    process.exit(1);
+}
+
+function ok(msg: string) {
+    console.log('  \u2713', msg);
+}
+
+const watchdog = setTimeout(() => {
+    console.error('\u274c TIMEOUT: virtual-socket-stress-test took too long');
+    process.exit(1);
+}, 20_000);
+watchdog.unref();
+
+async function main() {
+    const N = 200;
+    console.log(`[stress] ${N} concurrent ops per phase, single bridge, noListen broker`);
+
+    const broker = new Broker1({noListen: true, port: 0, host: '127.0.0.1'});
+    broker.emitter.on('warning', () => {});
+    const baselineConnected = broker.connectedClients.size;
+    const bridge = new InProcessBridge(broker);
+
+    const heap0 = process.memoryUsage().heapUsed;
+    const t0 = Date.now();
+
+    // ---------------------------------------------------------------
+    // Phase 1: N concurrent single-key acquires
+    // ---------------------------------------------------------------
+    const lockPromises: Promise<any>[] = [];
+    for (let i = 0; i < N; i++) {
+        lockPromises.push(bridge.lock({key: `stress-single-${i}`, ttl: 60_000}));
+    }
+    const pendingDuringLockBatch = bridge.pendingCount;
+    if (pendingDuringLockBatch !== N) {
+        fail(`pendingCount during lock batch = ${pendingDuringLockBatch}; expected ${N}`);
+    }
+    const lockReplies: any[] = await Promise.all(lockPromises);
+    const t1 = Date.now();
+
+    // Assert every reply is well-formed and unique. NB: for single-key
+    // grants the bridge does NOT surface a separate `lockUuid` — it
+    // reuses the request uuid (`_bridgeRequestUuid`) as the holder
+    // identity, which the HTTP layer (`http-server.ts:417`) re-exports
+    // as `lockUuid` in its public response. Match that semantic.
+    const grantedUuids = new Set<string>();
+    const fencingTokens: number[] = [];
+    for (let i = 0; i < N; i++) {
+        const r = lockReplies[i];
+        if (r.acquired !== true) fail(`lock[${i}].acquired=${r.acquired}; reply=${JSON.stringify(r)}`);
+        const holderUuid: string = r._bridgeRequestUuid;
+        if (typeof holderUuid !== 'string' || holderUuid.length === 0) {
+            fail(`lock[${i}] missing _bridgeRequestUuid`);
+        }
+        if (typeof r.fencingToken !== 'number' || r.fencingToken < 1) fail(`lock[${i}] bad fencingToken: ${r.fencingToken}`);
+        if (grantedUuids.has(holderUuid)) fail(`duplicate holder uuid at i=${i}: ${holderUuid}`);
+        grantedUuids.add(holderUuid);
+        fencingTokens.push(r.fencingToken);
+    }
+    if (grantedUuids.size !== N) fail(`grantedUuids.size=${grantedUuids.size}; expected ${N}`);
+    if (bridge.pendingCount !== 0) fail(`pendingCount post-lock = ${bridge.pendingCount}`);
+    if (broker.connectedClients.size !== baselineConnected + 1) {
+        fail(`connectedClients drifted: ${broker.connectedClients.size}, baseline+1=${baselineConnected + 1}`);
+    }
+    // Broker should see N held locks now.
+    if ((broker as any).locks.size !== N) {
+        fail(`broker.locks.size=${(broker as any).locks.size}; expected ${N}`);
+    }
+    ok(`phase 1: ${N} concurrent locks granted; ${grantedUuids.size} unique uuids; pendingCount=0 (${t1 - t0}ms)`);
+
+    // ---------------------------------------------------------------
+    // Phase 2: N concurrent acquireMany on overlapping shape
+    // ---------------------------------------------------------------
+    const amPromises: Promise<any>[] = [];
+    for (let i = 0; i < N; i++) {
+        amPromises.push(bridge.acquireMany([`am-a-${i}`, `am-b-${i}`, `am-c-${i}`], 60_000));
+    }
+    const amReplies: any[] = await Promise.all(amPromises);
+    const t2 = Date.now();
+
+    const amUuids = new Set<string>();
+    for (let i = 0; i < N; i++) {
+        const r = amReplies[i];
+        if (r.acquired !== true) fail(`am[${i}].acquired=${r.acquired}: ${JSON.stringify(r)}`);
+        if (!r.lockUuid) fail(`am[${i}] missing lockUuid`);
+        if (amUuids.has(r.lockUuid)) fail(`duplicate composite uuid at i=${i}`);
+        amUuids.add(r.lockUuid);
+        if (Object.keys(r.fencingTokens || {}).length !== 3) {
+            fail(`am[${i}].fencingTokens has ${Object.keys(r.fencingTokens || {}).length} entries; expected 3`);
+        }
+    }
+    if (bridge.pendingCount !== 0) fail(`pendingCount post-acquireMany = ${bridge.pendingCount}`);
+    // 3*N more keys held: N single-keys + 3*N composite-keys = 4*N total
+    if ((broker as any).locks.size !== 4 * N) {
+        fail(`broker.locks.size=${(broker as any).locks.size}; expected ${4 * N}`);
+    }
+    ok(`phase 2: ${N} concurrent acquireMany granted; broker.locks.size=${(broker as any).locks.size} (${t2 - t1}ms)`);
+
+    // ---------------------------------------------------------------
+    // Phase 3: N concurrent unlocks targeting phase-1 holds
+    // ---------------------------------------------------------------
+    const unlockPromises: Promise<any>[] = [];
+    for (let i = 0; i < N; i++) {
+        unlockPromises.push(bridge.unlock({
+            key: `stress-single-${i}`,
+            lockUuid: lockReplies[i]._bridgeRequestUuid,
+        }));
+    }
+    const unlockReplies: any[] = await Promise.all(unlockPromises);
+    const t3 = Date.now();
+
+    let unlockedOk = 0;
+    for (let i = 0; i < N; i++) {
+        if (unlockReplies[i].unlocked === true) unlockedOk++;
+    }
+    if (unlockedOk !== N) fail(`only ${unlockedOk}/${N} unlocks succeeded`);
+    if (bridge.pendingCount !== 0) fail(`pendingCount post-unlock = ${bridge.pendingCount}`);
+    ok(`phase 3: ${N} concurrent unlocks succeeded (${t3 - t2}ms)`);
+
+    // ---------------------------------------------------------------
+    // Phase 4: N concurrent releaseMany targeting phase-2 holds
+    // ---------------------------------------------------------------
+    const rmPromises: Promise<any>[] = [];
+    for (let i = 0; i < N; i++) {
+        rmPromises.push(bridge.releaseMany(amReplies[i].lockUuid));
+    }
+    const rmReplies: any[] = await Promise.all(rmPromises);
+    const t4 = Date.now();
+
+    let rmOk = 0;
+    for (let i = 0; i < N; i++) {
+        if (rmReplies[i].released === true) rmOk++;
+    }
+    if (rmOk !== N) fail(`only ${rmOk}/${N} releaseMany succeeded`);
+    ok(`phase 4: ${N} concurrent releaseMany succeeded (${t4 - t3}ms)`);
+
+    // ---------------------------------------------------------------
+    // Final invariants
+    // ---------------------------------------------------------------
+    if (bridge.pendingCount !== 0) fail(`pendingCount final = ${bridge.pendingCount}`);
+    if (broker.connectedClients.size !== baselineConnected + 1) {
+        fail(`connectedClients drifted post-stress: ${broker.connectedClients.size}`);
+    }
+
+    // Holders should be 0 across every key (LockObj may linger but
+    // empty). lockholders.size === 0 invariant.
+    let nonEmpty = 0;
+    for (const lock of ((broker as any).locks as Map<string, any>).values()) {
+        if (lock.lockholders && lock.lockholders.size > 0) nonEmpty++;
+    }
+    if (nonEmpty !== 0) fail(`${nonEmpty} keys still have lockholders > 0 after stress`);
+    ok(`all keys have 0 holders after release phase`);
+
+    const heap1 = process.memoryUsage().heapUsed;
+    const heapDeltaMb = ((heap1 - heap0) / 1024 / 1024).toFixed(2);
+    // Heap should not have ballooned. 4*N=800 lock objects in
+    // broker.locks plus the response history is well under 50MB.
+    const heapDeltaMbNum = (heap1 - heap0) / 1024 / 1024;
+    if (heapDeltaMbNum > 50) {
+        fail(`heap grew by ${heapDeltaMb}MB; expected < 50MB`);
+    }
+    ok(`heap delta = ${heapDeltaMb}MB (< 50MB threshold)`);
+
+    bridge.shutdown();
+    if (broker.connectedClients.size !== baselineConnected) {
+        fail(`bridge socket still in connectedClients after shutdown: size=${broker.connectedClients.size}`);
+    }
+    ok(`post-shutdown connectedClients=${broker.connectedClients.size} (back to baseline)`);
+
+    await new Promise<void>(r => broker.close(() => r()));
+    clearTimeout(watchdog);
+    console.log(`\n\u2705 virtual-socket-stress-test: ${4 * N} ops in ${t4 - t0}ms; heap +${heapDeltaMb}MB`);
+    process.exit(0);
+}
+
+main().catch(err => {
+    console.error('virtual-socket-stress-test threw:', err);
+    process.exit(1);
+});

--- a/test/virtual-socket-test.ts
+++ b/test/virtual-socket-test.ts
@@ -43,6 +43,26 @@
  *  15. End-to-end through the bridge: `await bridge.lock(...)`
  *      resolves only AFTER the broker's lock-handler has fully
  *      returned (proves the awaiter never observes mid-handler state).
+ *  16. FIFO is preserved across multiple separate `write()` calls
+ *      (cross-write order, not just within-buffer order).
+ *  17. Malformed JSON in `write()` is dropped silently (no error
+ *      emit, no callback rejection, surrounding valid frames still
+ *      flow).
+ *  18. `write('')` and `write('\n\n')` deliver no frames, no errors.
+ *  19. `onFrame` throwing emits an `'error'` event on the socket
+ *      and does NOT block subsequent frame delivery.
+ *  20. `end(payload)` writes the trailing payload (delivered to
+ *      `onFrame`) BEFORE running the `finish` -> `end` -> `close`
+ *      lifecycle, and `end()`'s callback fires after close.
+ *  21. `removeAllListeners('event')` is selective — only that
+ *      event's listeners are removed; siblings survive.
+ *  22. The LMX-extension `destroyTimeout` field is assignable and
+ *      reassignable (broker version-mismatch flow stores + clears
+ *      a Timer here).
+ *  23. Bridge integration: `bridge.shutdown()` rejects every
+ *      in-flight awaiter with `InProcessBridge: shutdown` (not a
+ *      dispatch timeout), and post-shutdown `bridge.lock()` rejects
+ *      synchronously with `InProcessBridge: closed`.
  *
  * Self-times-out at 8s. Any hang means a callback didn't fire or a
  * lifecycle event went missing.
@@ -381,8 +401,255 @@ async function main() {
         await new Promise<void>(r => broker.close(() => r()));
     }
 
+    // ===========================================================
+    // [16] Cross-write FIFO: frames from N separate write() calls
+    //      are delivered to onFrame in the order written.
+    // ===========================================================
+    console.log('\n[16] FIFO is preserved across multiple write() calls');
+    {
+        const frames: any[] = [];
+        const sock = new VirtualSocket(f => frames.push(f));
+        for (let i = 0; i < 25; i++) {
+            sock.write(`{"i":${i}}\n`);
+        }
+        const lenA = frames.length;
+        if (lenA !== 0) fail(`frames delivered sync inside write loop (got ${lenA})`);
+        await new Promise<void>(r => setImmediate(r));
+        const lenB = frames.length;
+        if (lenB !== 25) fail(`expected 25 frames; got ${lenB}`);
+        for (let i = 0; i < 25; i++) {
+            if (frames[i].i !== i) {
+                fail(`order broken at index ${i}; got ${JSON.stringify(frames.map(f => f.i))}`);
+            }
+        }
+        ok('25 frames from 25 separate write() calls delivered in order');
+    }
+
+    // ===========================================================
+    // [17] Malformed JSON in write() is dropped silently — does
+    //      NOT crash, does NOT reject the write callback, does NOT
+    //      emit 'error', does NOT block surrounding valid frames.
+    // ===========================================================
+    console.log('\n[17] malformed JSON frames are dropped silently');
+    {
+        const frames: any[] = [];
+        const errs: any[] = [];
+        const sock = new VirtualSocket(f => frames.push(f));
+        sock.on('error', e => errs.push(e));
+        let cbErr: any = 'NOT-CALLED';
+        sock.write(
+            'not json at all\n' +
+            '{"valid":1}\n' +
+            'totally bogus {trailing\n' +
+            '{"valid":2}\n',
+            'utf8',
+            err => { cbErr = err; },
+        );
+        await new Promise<void>(r => setImmediate(r));
+        if (cbErr !== null) fail(`write cb should fire with null on success; got ${cbErr}`);
+        if (errs.length !== 0) fail(`unexpected 'error' emit: ${errs.map(e => e.message).join(', ')}`);
+        if (frames.length !== 2) fail(`expected 2 valid frames; got ${frames.length}`);
+        if (frames[0].valid !== 1 || frames[1].valid !== 2) {
+            fail(`bad valid frames: ${JSON.stringify(frames)}`);
+        }
+        ok(`bogus lines silently dropped; 2 valid frames preserved`);
+    }
+
+    // ===========================================================
+    // [18] write('') and write('\n\n\n') deliver no frames and
+    //      cause no errors. The broker never writes empty frames
+    //      but the surface should be tolerant.
+    // ===========================================================
+    console.log('\n[18] empty / newline-only writes deliver no frames');
+    {
+        const frames: any[] = [];
+        const errs: any[] = [];
+        const sock = new VirtualSocket(f => frames.push(f));
+        sock.on('error', e => errs.push(e));
+        sock.write('');
+        sock.write('\n');
+        sock.write('\n\n\n\n');
+        await new Promise<void>(r => setImmediate(r));
+        if (frames.length !== 0) fail(`expected 0 frames; got ${frames.length}`);
+        if (errs.length !== 0) fail(`unexpected error emits: ${errs.map(e => e.message).join(', ')}`);
+        ok('no frames delivered, no errors emitted');
+    }
+
+    // ===========================================================
+    // [19] onFrame throwing emits an 'error' event on the socket
+    //      and does NOT crash the process or stall further frames.
+    // ===========================================================
+    console.log('\n[19] onFrame throwing -> error event, surrounding frames still flow');
+    {
+        let throwOnNext = true;
+        const seen: any[] = [];
+        const errs: any[] = [];
+        const sock = new VirtualSocket(f => {
+            if (throwOnNext) {
+                throwOnNext = false;
+                throw new Error('boom-in-onFrame');
+            }
+            seen.push(f);
+        });
+        sock.on('error', e => errs.push(e));
+        sock.write('{"a":1}\n');  // this one throws inside onFrame
+        sock.write('{"a":2}\n');  // this one is fine
+        await new Promise<void>(r => setImmediate(r));
+        if (errs.length !== 1) fail(`expected 1 error emit; got ${errs.length}`);
+        if (!errs[0] || !String(errs[0].message).includes('boom-in-onFrame')) {
+            fail(`unexpected error: ${errs[0]?.message}`);
+        }
+        if (seen.length !== 1 || seen[0].a !== 2) {
+            fail(`expected the second frame to still arrive; got ${JSON.stringify(seen)}`);
+        }
+        ok(`error event fired with original Error; subsequent frame still delivered`);
+    }
+
+    // ===========================================================
+    // [20] end(payload) drains the trailing write THEN runs the
+    //      finish -> end -> close lifecycle in order.
+    // ===========================================================
+    console.log('\n[20] end(payload) delivers trailing frame BEFORE close');
+    {
+        const frames: any[] = [];
+        const events: string[] = [];
+        const sock = new VirtualSocket(f => {
+            frames.push(f);
+            events.push(`frame#${(f as any).n}`);
+        });
+        sock.on('finish', () => events.push('finish'));
+        sock.on('end', () => events.push('end'));
+        sock.on('close', () => events.push('close'));
+
+        let endCbFired = false;
+        sock.end('{"n":1}\n', 'utf8', () => { endCbFired = true; });
+
+        await new Promise<void>(r => setImmediate(r));
+        await new Promise<void>(r => setImmediate(r)); // an extra macrotask for safety
+
+        if (!endCbFired) fail('end() callback did not fire');
+        if (frames.length !== 1) fail(`expected 1 trailing frame; got ${frames.length}`);
+        if (frames[0].n !== 1) fail(`bad trailing frame: ${JSON.stringify(frames[0])}`);
+        // Frame must arrive BEFORE finish/end/close.
+        const frameIdx = events.indexOf('frame#1');
+        const finishIdx = events.indexOf('finish');
+        const closeIdx = events.indexOf('close');
+        if (frameIdx === -1 || finishIdx === -1 || closeIdx === -1) {
+            fail(`missing event in stream: ${events}`);
+        }
+        if (!(frameIdx < finishIdx && finishIdx < closeIdx)) {
+            fail(`out-of-order: ${events}`);
+        }
+        if (sock.destroyed !== true) fail('socket should be destroyed after end()');
+        ok(`trailing frame -> finish -> end -> close in order: ${events}`);
+    }
+
+    // ===========================================================
+    // [21] removeAllListeners('event') is selective — only that
+    //      event's listeners are removed, others survive.
+    // ===========================================================
+    console.log('\n[21] removeAllListeners(event) is selective');
+    {
+        const sock = new VirtualSocket(() => {});
+        let aCount = 0;
+        let bCount = 0;
+        sock.on('a', () => { aCount++; });
+        sock.on('a', () => { aCount++; });
+        sock.on('b', () => { bCount++; });
+        sock.removeAllListeners('a');
+        sock.emit('a');
+        sock.emit('a');
+        sock.emit('b');
+        if (aCount !== 0) fail(`'a' listeners should be gone; saw aCount=${aCount}`);
+        if (bCount !== 1) fail(`'b' listener should fire once; saw bCount=${bCount}`);
+        ok(`'a' listeners removed; 'b' listener intact`);
+    }
+
+    // ===========================================================
+    // [22] destroyTimeout (LMX-extension) is assignable + clearable
+    //      — broker version-mismatch flow stores a Timer here, then
+    //      clears it on receiving the version-mismatch ack.
+    // ===========================================================
+    console.log('\n[22] destroyTimeout LMX extension behaves');
+    {
+        const sock = new VirtualSocket(() => {});
+        if (sock.destroyTimeout !== undefined) fail(`initial destroyTimeout: ${sock.destroyTimeout}`);
+        const t = setTimeout(() => {}, 60_000);
+        sock.destroyTimeout = t;
+        if (sock.destroyTimeout !== t) fail('destroyTimeout assignment did not stick');
+        clearTimeout(sock.destroyTimeout);
+        sock.destroyTimeout = undefined;
+        if (sock.destroyTimeout !== undefined) fail('destroyTimeout reset failed');
+        ok('destroyTimeout: undefined -> Timer -> undefined transitions');
+    }
+
+    // ===========================================================
+    // [23] Bridge: shutdown() rejects all in-flight awaiters with a
+    //      clear error. Locks an idle broker by stubbing
+    //      broker.lock to never-reply, then asserts every awaiter
+    //      gets `InProcessBridge: shutdown` (not the dispatch
+    //      timeout — shutdown should win the race even with the
+    //      default 60s timeout still ticking).
+    // ===========================================================
+    console.log('\n[23] bridge.shutdown() rejects all in-flight awaiters');
+    {
+        const broker = new Broker1({noListen: true, port: 0, host: '127.0.0.1'});
+        broker.emitter.on('warning', () => {});
+        const bridge = new InProcessBridge(broker);
+
+        // Stub lock/unlock/etc to be no-ops so requests pend forever.
+        (broker as any).lock = () => {};
+        (broker as any).unlock = () => {};
+        (broker as any).acquireMany = () => {};
+        (broker as any).releaseMany = () => {};
+
+        const promises = [
+            bridge.lock({key: 'p-1', ttl: 5000}),
+            bridge.lock({key: 'p-2', ttl: 5000}),
+            bridge.acquireMany(['x', 'y'], 5000),
+            bridge.releaseMany('fake-uuid'),
+            bridge.unlock({key: 'p-3'}),
+        ];
+
+        const pendingNow = bridge.pendingCount;
+        if (pendingNow !== promises.length) {
+            fail(`pendingCount=${pendingNow}, expected ${promises.length}`);
+        }
+        ok(`pendingCount=${pendingNow} before shutdown`);
+
+        bridge.shutdown();
+
+        const settled = await Promise.allSettled(promises);
+        for (let i = 0; i < settled.length; i++) {
+            const s = settled[i];
+            if (s.status !== 'rejected') {
+                fail(`promise[${i}] resolved instead of rejecting: ${JSON.stringify((s as any).value)}`);
+            }
+            const msg = String((s as any).reason?.message ?? s.reason);
+            if (!msg.includes('shutdown')) {
+                fail(`promise[${i}] rejected with non-shutdown error: ${msg}`);
+            }
+        }
+        if (bridge.pendingCount !== 0) fail(`pendingCount=${bridge.pendingCount} after shutdown`);
+        ok(`all ${promises.length} pending awaiters rejected with 'shutdown' error; pendingCount=0`);
+
+        // Sanity: a NEW dispatch on a closed bridge should reject
+        // immediately with `InProcessBridge: closed`, not pend.
+        try {
+            await bridge.lock({key: 'after-shutdown', ttl: 1000});
+            fail('expected lock-after-shutdown to reject');
+        } catch (err: any) {
+            if (!String(err.message).includes('closed')) {
+                fail(`expected 'closed'; got ${err.message}`);
+            }
+            ok('post-shutdown dispatch rejects with InProcessBridge: closed');
+        }
+
+        await new Promise<void>(r => broker.close(() => r()));
+    }
+
     clearTimeout(watchdog);
-    console.log('\n\u2705 virtual-socket-test: all 15 checks passed');
+    console.log('\n\u2705 virtual-socket-test: all 23 checks passed');
     process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

Builds on the hardened `VirtualSocket` from #129 with:

* **8 more cases (16-23) in `test/virtual-socket-test.ts`** covering cross-write FIFO, malformed-JSON tolerance, empty writes, `onFrame` throwing, `end(payload)` lifecycle ordering, selective `removeAllListeners`, the `destroyTimeout` LMX extension, and bridge-shutdown semantics for in-flight awaiters.
* **`test/virtual-socket-stress-test.ts`** drives **800 concurrent ops** (200 lock + 200 acquireMany + 200 unlock + 200 releaseMany) through a single bridge and asserts strict invariants on `connectedClients`, `pendingCount`, `broker.locks.size`, leftover holders, heap delta, and post-shutdown cleanup.

Together these lock in:
* `inflight` correlation-map correctness under concurrent dispatch
* FIFO `process.nextTick` frame delivery across many write calls
* lifecycle event ordering (`finish` -> `end` -> `close`) including the trailing-payload variant
* `bridge.shutdown()` rejecting every pending awaiter with `InProcessBridge: shutdown` (not a dispatch timeout) and refusing further dispatches with `InProcessBridge: closed`
* zero socket / connection / lock leaks across 800 ops (heap +~2.3 MB, all 4*N keys end with 0 holders)

## Local results

```
[stress] 200 concurrent ops per phase, single bridge, noListen broker
  ✓ phase 1: 200 concurrent locks granted; 200 unique uuids; pendingCount=0 (7ms)
  ✓ phase 2: 200 concurrent acquireMany granted; broker.locks.size=800 (13ms)
  ✓ phase 3: 200 concurrent unlocks succeeded (3ms)
  ✓ phase 4: 200 concurrent releaseMany succeeded (4ms)
  ✓ all keys have 0 holders after release phase
  ✓ heap delta = 2.30MB (< 50MB threshold)
  ✓ post-shutdown connectedClients=0 (back to baseline)

✅ virtual-socket-stress-test: 800 ops in 27ms; heap +2.30MB
```

```
✅ virtual-socket-test: all 23 checks passed
```

## Regression sweep

All green on `dev` + this branch, on the same checkout:

* `in-process-bridge-test`
* `admin-controls-test`, `admin-otel-toggle-test`
* `quick-verification-test`, `improvements-test`
* `rw-lock-simple-test`, `rw-rapid-cycles-test`, `quick-rw-test`, `rw-max-limits-test`, `rw-lock-standalone-test`, `comprehensive-rw-lock-test`
* `acquire-many-queueing-test`
* `chaos-fuzz-test` (7 scenarios)

## Notes

* Pure test additions — no runtime behavior changes, no image bump needed; the existing `0.2.25-dd.3` image already exhibits the behavior these tests pin down.
* `quick-memory-test.ts` hard-codes port 8888 and is not part of this sweep (pre-existing, environmental).

## Test plan

- [x] `npm run compile`
- [x] `npx ts-node test/virtual-socket-test.ts` (23 cases, ~6s)
- [x] `npx ts-node test/virtual-socket-stress-test.ts` (~30ms wall, +~2.3MB heap)
- [x] Regression sweep against the existing test suite (see above)

Made with [Cursor](https://cursor.com)