### PR TITLE
fix(broker): plug phantom-unlock + semaphore-cleanup-collateral races; verify TTL sweeper

### DIFF
--- a/src/broker-1.ts
+++ b/src/broker-1.ts
@@ -1006,26 +1006,48 @@ export class Broker1 {
 
             const notify = lockObj.notify;
 
-            for (const uuid of Object.keys(uuids)) {
+            // Scrub the closing client's queued waiter entries from
+            // this key's notify list. The previous implementation
+            // wrote `for (const uuid of Object.keys(uuids))` against
+            // an array, which iterates string indices ('0','1',...)
+            // instead of the actual uuids — silently leaving stale
+            // entries in the queue that a later grant cycle would
+            // try to wake on a dead socket.
+            for (const uuid of uuids) {
                 notify.remove(uuid);
             }
 
-            // Drop the centralised deadline rows for this client's
-            // holders so the sweeper doesn't bother visiting them.
-            // The actual `unlock(force:true)` call below will also
-            // prune any stragglers, but it's cheap to do it here too.
-            for (const lockholder of lockObj.lockholders.values()) {
-                if (lockholder.ws === ws) {
-                    this.holderDeadlines.delete(lockholder.uuid);
+            // Walk the holders for THIS key and figure out which ones
+            // belong to the closing socket. Only those should be
+            // released. The previous implementation called
+            // `unlock({force:true, key:k}, ws)` without a `_uuid`,
+            // which fell into the wipe-all branch and evicted every
+            // peer holder on the key — fine for `max=1` keys where
+            // the closing client was the sole holder, catastrophic
+            // for semaphores (`max>1`) where peer clients were still
+            // alive and counted on their slot.
+            const myHolderUuids: string[] = [];
+            for (const [holderUuid, holder] of lockObj.lockholders) {
+                if (holder.ws === ws) {
+                    myHolderUuids.push(holderUuid);
+                    this.holderDeadlines.delete(holderUuid);
                 }
             }
-
-            if (lockObj.isViaShell !== true) {
-                // delete lockObj[k];
-                this.unlock({force: true, key: k, from: 'client socket closed/ended/errored'}, ws);
+            if (myHolderUuids.length === 0) {
+                continue;
             }
-            else if (!lockObj.keepLocksAfterDeath) {
-                this.unlock({force: true, key: k, from: 'client socket closed/ended/errored'}, ws);
+
+            const shouldRelease =
+                lockObj.isViaShell !== true || !lockObj.keepLocksAfterDeath;
+            if (!shouldRelease) continue;
+
+            for (const holderUuid of myHolderUuids) {
+                this.unlock({
+                    force: true,
+                    key: k,
+                    _uuid: holderUuid,
+                    from: 'client socket closed/ended/errored',
+                }, ws);
             }
 
         }
@@ -2380,35 +2402,74 @@ export class Broker1 {
 
             const ln = lck.notify.length;
 
-            // Drop the deadline row first — the centralised sweeper
-            // (`tickTtl`) is the only thing that fires evictions now,
-            // so removing the entry here keeps the sweep cheap and
-            // avoids a phantom eviction message racing this unlock.
-            if (_uuid) this.holderDeadlines.delete(_uuid);
+            // Phase 1 — targeted holder removal. Capture whether the
+            // caller's `_uuid` actually matched a live holder so
+            // downstream branches can distinguish "I unlocked my own
+            // hold" from "I sent force=true with a stale or invalid
+            // _uuid". Drop the deadline row alongside the holder so
+            // the centralised sweeper (`tickTtl`) doesn't emit a
+            // phantom eviction message racing this unlock.
+            let wasHolder = false;
+            if (_uuid && lck.lockholders.has(_uuid)) {
+                this.holderDeadlines.delete(_uuid);
+                lck.lockholders.delete(_uuid);
+                // Mark for late-unlock idempotency: if the same caller
+                // retries (e.g. their first unlock crossed paths with
+                // a TTL eviction or a duplicate cleanup), the second
+                // request gets `unlocked:true` instead of "wrong uuid".
+                lck.lockholdersAllReleased[_uuid] = true;
+                wasHolder = true;
+            }
 
-            // remove the lockholder, as the above if stmt checked it,
-            //so we don't need to check before deleting it again.
-            lck.lockholders.delete(_uuid);
-
-            // delete lck.lockholderTimeouts[_uuid];
-
+            // Phase 2 — force-mode dispositions. Three sub-cases that
+            // historically conflated to a single wipe-all branch and
+            // produced two latent bugs:
+            //
+            //   (a) `force:true` with no `_uuid` — used by
+            //       `cleanupConnection` and by operator-driven
+            //       wholesale resets. Keep the legacy "wipe everyone
+            //       on this key" semantic.
+            //   (b) `force:true` with a `_uuid` that DID match (handled
+            //       in Phase 1 above; nothing more to do here).
+            //   (c) `force:true` with a `_uuid` that did NOT match.
+            //       Previously this fell into the wipe-all branch on
+            //       max=1 keys and silently no-op'd on max>1 keys
+            //       while still reporting `unlocked:true`. Both were
+            //       wrong:
+            //         - max=1: an attacker passing a wrong `_uuid`
+            //                  could evict the legitimate holder.
+            //         - max>1: the broker reported success while the
+            //                  lockholders map still had every peer
+            //                  ("phantom unlock"), confusing CAS
+            //                  callers downstream.
+            //       Fail loudly in both, keep peers untouched.
             if (force) {
-                // If this is a semaphore lock and we're just targeting one lock holder,
-                // only remove that specific holder
-                if (_uuid && lck.max > 1) {
-                    // Just remove this specific lock holder
-                    const removed = lck.lockholders.delete(_uuid);
-                    if (removed) {
-                        lck.lockholdersAllReleased[_uuid] = true;
-                    }
-                } else {
-                    // Traditional force behavior - remove all lock holders
+                if (!_uuid) {
+                    // (a) legacy wipe-all
                     for (const k of lck.lockholders.keys()) {
                         lck.lockholdersAllReleased[k] = true;
                         this.holderDeadlines.delete(k);
                     }
                     lck.lockholders = new Map();
+                } else if (!wasHolder) {
+                    // (c) targeted force on a non-existent holder.
+                    // Reply with a structured error and DO NOT touch
+                    // any peer's hold or fall through to "unlocked:true".
+                    if (uuid && ws) {
+                        log.debug('unlock: rejecting force-unlock with non-matching _uuid for key:', key, 'uuid:', uuid, '_uuid:', _uuid);
+                        this.send(ws, {
+                            uuid: uuid,
+                            key: key,
+                            lockRequestCount: ln,
+                            type: 'unlock',
+                            unlocked: false,
+                            error: `force-unlock: no holder with _uuid='${_uuid}' on key '${key}' (max=${lck.max}).`,
+                        });
+                    }
+                    // Don't drain the queue — nothing actually freed up.
+                    return;
                 }
+                // (b) handled by Phase 1; fall through to send unlocked:true.
             }
 
             if (uuid && ws) {

--- a/test/ttl-sweeper-test.ts
+++ b/test/ttl-sweeper-test.ts
@@ -1,0 +1,291 @@
+'use strict';
+
+/**
+ * Direct verification that the centralised TTL sweeper actually
+ * evicts expired holders WITHOUT relying on `tickTtl()` being
+ * called manually. The chaos-fuzz-extra `s10` scenario explicitly
+ * stops the auto-sweeper to drive eviction synchronously; this
+ * test does the inverse — leaves the automatic `setInterval`
+ * running, sets a TTL shorter than the sweep cadence, and
+ * verifies that:
+ *
+ *   t1  An expired holder is removed from `lockholders` within a
+ *       small bounded window (< 5 sweep intervals).
+ *
+ *   t2  An expired holder's deadline row is also gone from
+ *       `holderDeadlines` after eviction.
+ *
+ *   t3  `lockholderTimeouts[holderUuid]` is set to `true` after
+ *       the sweeper evicts, so a late `unlock` from the racy
+ *       ex-holder gets `unlocked:true` rather than
+ *       "wrong-uuid" error.
+ *
+ *   t4  After eviction, a queued waiter is granted automatically
+ *       (the sweeper calls `ensureNewLockHolder`).
+ *
+ *   t5  `ttlEvictionsTotal` stat counter increments.
+ *
+ *   t6  The sweeper does NOT touch holders whose `expiresAt` is
+ *       still in the future. Sanity: a long-TTL hold survives
+ *       the same window.
+ *
+ *   t7  `stopTtlSweeper()` halts evictions; expired holders
+ *       remain until restart.
+ *
+ * Self-times-out at 15s. Default sweep interval is 25ms, so
+ * every probe loop runs in milliseconds.
+ */
+
+import {Broker1} from '../dist/main';
+import {EventEmitter} from 'events';
+import {v4 as uuidV4} from 'uuid';
+
+function fail(msg: string): never {
+    console.error('\u274c FAIL:', msg);
+    process.exit(1);
+}
+function ok(msg: string) { console.log('  \u2713', msg); }
+
+const watchdog = setTimeout(() => {
+    console.error('\u274c TIMEOUT: ttl-sweeper-test took too long');
+    process.exit(1);
+}, 15_000);
+watchdog.unref();
+
+class FakeSocket extends EventEmitter {
+    public writable = true;
+    public readable = true;
+    public destroyed = false;
+    public lmxClosed = false;
+    public destroyTimeout: NodeJS.Timeout | undefined = undefined;
+    public framesIn: any[] = [];
+    public bytesWritten = 0;
+    public bytesRead = 0;
+    public allowHalfOpen = false;
+    public localAddress = 'fake';
+    public localPort = 0;
+    public remoteAddress = 'fake';
+    public remoteFamily: 'IPv4' | 'IPv6' = 'IPv4';
+    public remotePort = 0;
+    public timeout = 0;
+    constructor() { super(); this.setMaxListeners(64); }
+    write(data: any, _enc?: any, cb?: any): boolean {
+        const text = typeof data === 'string' ? data : Buffer.isBuffer(data) ? data.toString('utf8') : String(data);
+        for (const line of text.split('\n')) {
+            if (!line) continue;
+            try { this.framesIn.push(JSON.parse(line)); } catch {/* ignore */}
+        }
+        if (cb) process.nextTick(cb, null);
+        return true;
+    }
+    end(): this { this.writable = false; return this; }
+    destroy(): this { this.writable = false; this.destroyed = true; return this; }
+    address() { return {address: this.localAddress, family: this.remoteFamily, port: this.localPort}; }
+    pipe<T>(t: T): T { return t; }
+    unpipe(): this { return this; }
+    setNoDelay(): this { return this; }
+    setKeepAlive(): this { return this; }
+    setTimeout(t: number): this { this.timeout = t; return this; }
+    setEncoding(): this { return this; }
+    unref(): this { return this; }
+    ref(): this { return this; }
+    pause(): this { return this; }
+    resume(): this { return this; }
+    cork(): void {}
+    uncork(): void {}
+    get readyState() { return this.destroyed ? 'closed' : 'open'; }
+}
+
+function newBroker(): any {
+    const b = new Broker1({noListen: true, port: 0, host: '127.0.0.1'});
+    if (b.emitter && typeof b.emitter.on === 'function') {
+        b.emitter.on('warning', () => {});
+        b.emitter.on('error', () => {});
+    }
+    return b;
+}
+
+function register(broker: any, ws: FakeSocket) {
+    broker.connectedClients.add(ws);
+    broker.wsToKeys.set(ws, {});
+    broker.wsToUUIDs.set(ws, {});
+}
+
+function lockSync(broker: any, ws: FakeSocket, payload: any): any {
+    broker.lock(payload, ws);
+    return ws.framesIn[ws.framesIn.length - 1];
+}
+
+async function waitForCondition(predicate: () => boolean, label: string, timeoutMs: number = 1000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (predicate()) return;
+        await new Promise(r => setTimeout(r, 10));
+    }
+    fail(`timed out waiting for: ${label}`);
+}
+
+async function main() {
+    // =============================================================
+    // t1 + t2 + t3 + t5 — auto-sweeper evicts; deadlines + holders
+    //                     coherent; lockholderTimeouts marker set;
+    //                     ttlEvictionsTotal increments.
+    // =============================================================
+    console.log('[t1-t3,t5] auto-sweeper evicts an expired holder; bookkeeping consistent');
+    {
+        const broker = newBroker();
+        try {
+            const key = 'sweep-1';
+            const ws = new FakeSocket();
+            register(broker, ws);
+
+            const beforeEvictions = broker.ttlEvictionsTotal ?? 0;
+            const u = uuidV4();
+            const reply = lockSync(broker, ws, {type: 'lock', uuid: u, key, ttl: 75, max: 1, force: false, pid: 1, retryCount: 0});
+            if (reply?.acquired !== true) fail(`expected acquired:true; got ${JSON.stringify(reply)}`);
+
+            // Sanity: holder is in lockholders + a deadline row exists for it.
+            if (broker.locks.get(key)?.lockholders?.size !== 1) {
+                fail(`pre-sweep: lockholders.size=${broker.locks.get(key)?.lockholders?.size}`);
+            }
+            const holderUuid = broker.locks.get(key).lockholders.keys().next().value as string;
+            if (!broker.holderDeadlines.has(holderUuid)) {
+                fail(`pre-sweep: deadline row missing for holder=${holderUuid}`);
+            }
+
+            // Wait long enough for ttl=75ms + at least 4 sweep intervals (25ms each).
+            await waitForCondition(
+                () => (broker.locks.get(key)?.lockholders?.size ?? 0) === 0,
+                'lockholders cleared by auto-sweeper',
+                2000,
+            );
+            ok(`t1: holder evicted by auto-sweeper within ttl + a few sweep intervals`);
+
+            if (broker.holderDeadlines.has(holderUuid)) {
+                fail(`t2: deadline row leaked after eviction (holder=${holderUuid})`);
+            }
+            ok(`t2: deadline row removed alongside holder`);
+
+            const lockObj = broker.locks.get(key);
+            if (!lockObj.lockholderTimeouts || lockObj.lockholderTimeouts[holderUuid] !== true) {
+                fail(`t3: lockholderTimeouts[${holderUuid}] not set after eviction; got ${JSON.stringify(lockObj.lockholderTimeouts)}`);
+            }
+            ok(`t3: lockholderTimeouts[${holderUuid}] = true (late-unlock idempotency marker)`);
+
+            const afterEvictions = broker.ttlEvictionsTotal ?? 0;
+            if (afterEvictions <= beforeEvictions) {
+                fail(`t5: ttlEvictionsTotal did not increment (before=${beforeEvictions}, after=${afterEvictions})`);
+            }
+            ok(`t5: ttlEvictionsTotal incremented (${beforeEvictions} -> ${afterEvictions})`);
+        } finally {
+            await new Promise<void>(r => broker.close(() => r()));
+        }
+    }
+
+    // =============================================================
+    // t4 — eviction wakes a queued waiter
+    // =============================================================
+    console.log('\n[t4] auto-sweeper triggers ensureNewLockHolder for a queued waiter');
+    {
+        const broker = newBroker();
+        try {
+            const key = 'sweep-2';
+            const wsHolder = new FakeSocket();
+            const wsWaiter = new FakeSocket();
+            register(broker, wsHolder);
+            register(broker, wsWaiter);
+
+            const uH = uuidV4();
+            lockSync(broker, wsHolder, {type: 'lock', uuid: uH, key, ttl: 60, max: 1, force: false, pid: 1, retryCount: 0});
+
+            const uW = uuidV4();
+            const queueReply = lockSync(broker, wsWaiter, {type: 'lock', uuid: uW, key, ttl: 30_000, max: 1, force: false, pid: 2, retryCount: 0});
+            if (queueReply?.acquired !== false) fail(`waiter should be queued (acquired:false); got ${JSON.stringify(queueReply)}`);
+            if ((broker.locks.get(key)?.notify?.length ?? 0) < 1) fail(`waiter not in notify queue`);
+
+            // Wait for the auto-sweeper to evict the holder and grant the waiter.
+            await waitForCondition(
+                () => wsWaiter.framesIn.some(f => f?.type === 'lock' && f.acquired === true),
+                'waiter granted after holder eviction',
+                2000,
+            );
+            const grant = wsWaiter.framesIn.find(f => f?.type === 'lock' && f.acquired === true);
+            ok(`t4: waiter received acquired:true after auto-sweep eviction (fencingToken=${grant?.fencingToken})`);
+        } finally {
+            await new Promise<void>(r => broker.close(() => r()));
+        }
+    }
+
+    // =============================================================
+    // t6 — sweeper does NOT touch a still-valid holder
+    // =============================================================
+    console.log('\n[t6] auto-sweeper leaves still-valid (long-TTL) holders alone');
+    {
+        const broker = newBroker();
+        try {
+            const key = 'sweep-3';
+            const ws = new FakeSocket();
+            register(broker, ws);
+
+            const u = uuidV4();
+            lockSync(broker, ws, {type: 'lock', uuid: u, key, ttl: 5_000, max: 1, force: false, pid: 1, retryCount: 0});
+            const holderUuid = broker.locks.get(key).lockholders.keys().next().value as string;
+
+            // Run the sweeper for ~10x its interval and check the
+            // holder is still present.
+            await new Promise(r => setTimeout(r, 250));
+            if ((broker.locks.get(key)?.lockholders?.size ?? 0) !== 1) {
+                fail(`t6: long-TTL holder evicted prematurely after 250ms`);
+            }
+            if (!broker.holderDeadlines.has(holderUuid)) {
+                fail(`t6: deadline row vanished for still-valid holder`);
+            }
+            ok(`t6: long-TTL holder + deadline row both still present after 250ms (10 sweep intervals)`);
+        } finally {
+            await new Promise<void>(r => broker.close(() => r()));
+        }
+    }
+
+    // =============================================================
+    // t7 — stopTtlSweeper halts evictions
+    // =============================================================
+    console.log('\n[t7] stopTtlSweeper halts further evictions');
+    {
+        const broker = newBroker();
+        try {
+            const key = 'sweep-4';
+            const ws = new FakeSocket();
+            register(broker, ws);
+
+            broker.stopTtlSweeper();
+
+            const u = uuidV4();
+            lockSync(broker, ws, {type: 'lock', uuid: u, key, ttl: 30, max: 1, force: false, pid: 1, retryCount: 0});
+
+            // Wait well past the TTL — without the sweeper, the
+            // holder must still be present.
+            await new Promise(r => setTimeout(r, 250));
+            const remaining = broker.locks.get(key)?.lockholders?.size ?? 0;
+            if (remaining !== 1) {
+                fail(`t7: holder evicted with sweeper stopped (lockholders.size=${remaining})`);
+            }
+            ok(`t7: holder survives past TTL when sweeper stopped (manual tickTtl required)`);
+
+            // Manual tick should now evict it.
+            const evicted = broker.tickTtl();
+            if (evicted < 1) fail(`t7: manual tickTtl evicted ${evicted} (expected >=1)`);
+            ok(`t7: manual tickTtl evicted ${evicted} entries after sweeper stop`);
+        } finally {
+            await new Promise<void>(r => broker.close(() => r()));
+        }
+    }
+
+    clearTimeout(watchdog);
+    console.log('\n\u2705 ttl-sweeper-test: all 7 properties verified');
+    process.exit(0);
+}
+
+main().catch(err => {
+    console.error('ttl-sweeper-test threw:', err);
+    process.exit(1);
+});

--- a/test/unlock-race-test.ts
+++ b/test/unlock-race-test.ts
@@ -1,0 +1,353 @@
+'use strict';
+
+/**
+ * Regression tests for the broker's unlock + cleanupConnection paths.
+ * Targets four discrete failure modes that surfaced during the
+ * VirtualSocket / sweeper hardening work:
+ *
+ *   r1  Phantom-unlock-with-wrong-_uuid (semaphore, max>1): a
+ *       caller sends `{type:'unlock', _uuid:'WRONG', force:true}`
+ *       on a key with two living holders. Current code reports
+ *       `unlocked:true` even though neither holder was removed
+ *       AND the lock object still has both holders. The reply
+ *       should NOT claim `unlocked:true` when no holder was
+ *       actually removed.
+ *
+ *   r2  Phantom-unlock-with-wrong-_uuid (exclusive, max=1): same
+ *       call shape, on a key with `max=1`. Current code falls into
+ *       the "Traditional force behavior - remove all lock holders"
+ *       else-branch and **wipes the unrelated valid holder** even
+ *       though `_uuid` doesn't match. That's a worse-than-phantom:
+ *       the caller can evict somebody else's hold by guessing.
+ *
+ *   r3  cleanupConnection over-evicts a semaphore: client A and
+ *       client B both hold key K (max=2). Client A drops the
+ *       socket without releasing. The broker's cleanup walks
+ *       lockObj and calls `unlock({force:true, key:k}, ws)`
+ *       without `_uuid`, which falls into the wipe-all branch and
+ *       evicts BOTH A's slot AND B's still-valid slot. After
+ *       cleanup, B's slot must still be present.
+ *
+ *   r4  cleanupConnection's notify-queue scrub uses
+ *       `Object.keys(uuids)` where `uuids` is already an Array.
+ *       That iterates string indices `'0','1',…` and never
+ *       removes the actual uuid keys, leaving stale waiter
+ *       entries from the closing client in the notify queue. A
+ *       future grant cycle would target a dead `ws`. We assert
+ *       the closing client's queued-but-not-granted requests are
+ *       removed from `lck.notify`.
+ *
+ * Self-times-out at 30s. Each scenario is fully self-contained
+ * (`noListen` broker; in-proc only). No TCP, no port allocation.
+ */
+
+import * as assert from 'assert';
+import {Broker1} from '../dist/main';
+import {v4 as uuidV4} from 'uuid';
+import {EventEmitter} from 'events';
+
+function fail(msg: string): never {
+    console.error('\u274c FAIL:', msg);
+    process.exit(1);
+}
+function ok(msg: string) { console.log('  \u2713', msg); }
+
+const watchdog = setTimeout(() => {
+    console.error('\u274c TIMEOUT: unlock-race-test took too long');
+    process.exit(1);
+}, 30_000);
+watchdog.unref();
+
+/**
+ * Minimal stand-in for an LMXSocket used by the broker hot path.
+ * The broker reads `writable`, `lmxClosed`, calls `write()` for
+ * reply frames and listens for `close`/`end`/`error`. We do NOT
+ * use VirtualSocket here because we want to inspect every reply
+ * frame the broker emits to a given client without the
+ * InProcessBridge correlation map in the way.
+ */
+class FakeSocket extends EventEmitter {
+    public writable = true;
+    public readable = true;
+    public destroyed = false;
+    public lmxClosed = false;
+    public destroyTimeout: NodeJS.Timeout | undefined = undefined;
+    public framesIn: any[] = [];
+    public bytesWritten = 0;
+    public bytesRead = 0;
+    public allowHalfOpen = false;
+    public localAddress = 'fake';
+    public localPort = 0;
+    public remoteAddress = 'fake';
+    public remoteFamily: 'IPv4' | 'IPv6' = 'IPv4';
+    public remotePort = 0;
+    public timeout = 0;
+
+    constructor() {
+        super();
+        this.setMaxListeners(64);
+    }
+
+    write(data: any, _enc?: any, cb?: (err?: Error | null) => void): boolean {
+        if (this.destroyed) {
+            if (cb) process.nextTick(cb, Object.assign(new Error('destroyed'), {code: 'ERR_STREAM_DESTROYED'}));
+            return false;
+        }
+        const text = typeof data === 'string' ? data
+            : Buffer.isBuffer(data) ? data.toString('utf8')
+            : String(data);
+        this.bytesWritten += Buffer.byteLength(text);
+        for (const line of text.split('\n')) {
+            if (!line) continue;
+            try {
+                this.framesIn.push(JSON.parse(line));
+            } catch {
+                // ignore
+            }
+        }
+        if (cb) process.nextTick(cb, null);
+        return true;
+    }
+
+    end(): this {
+        this.writable = false;
+        process.nextTick(() => {
+            this.readable = false;
+            this.destroyed = true;
+            this.lmxClosed = true;
+            this.emit('end');
+            this.emit('close', false);
+        });
+        return this;
+    }
+
+    destroy(): this {
+        this.writable = false;
+        this.readable = false;
+        this.destroyed = true;
+        this.lmxClosed = true;
+        process.nextTick(() => this.emit('close', false));
+        return this;
+    }
+
+    address() { return {address: this.localAddress, family: this.remoteFamily, port: this.localPort}; }
+    pipe<T>(t: T): T { return t; }
+    unpipe(): this { return this; }
+    setNoDelay(): this { return this; }
+    setKeepAlive(): this { return this; }
+    setTimeout(t: number): this { this.timeout = t; return this; }
+    setEncoding(): this { return this; }
+    unref(): this { return this; }
+    ref(): this { return this; }
+    pause(): this { return this; }
+    resume(): this { return this; }
+    cork(): void {}
+    uncork(): void {}
+    get readyState() {
+        if (this.destroyed) return 'closed';
+        if (this.writable && this.readable) return 'open';
+        return 'closed';
+    }
+}
+
+/**
+ * Drive the broker-side hot path by calling the same `lock()` /
+ * `unlock()` methods that the TCP `onData` dispatch invokes
+ * directly. Returns the broker's reply frame, captured from the
+ * fake socket's write buffer.
+ */
+function lockSync(broker: any, ws: FakeSocket, payload: any): any {
+    const before = ws.framesIn.length;
+    broker.lock(payload, ws);
+    return ws.framesIn[ws.framesIn.length - 1] ?? null;
+}
+function unlockSync(broker: any, ws: FakeSocket, payload: any): any {
+    broker.unlock(payload, ws);
+    return ws.framesIn[ws.framesIn.length - 1] ?? null;
+}
+
+function newBroker(): any {
+    const b = new Broker1({noListen: true, port: 0, host: '127.0.0.1'});
+    if (b.emitter && typeof b.emitter.on === 'function') {
+        b.emitter.on('warning', () => {});
+        b.emitter.on('error', () => {});
+    }
+    return b;
+}
+
+async function main() {
+    // =============================================================
+    // r1 — semaphore phantom unlock with wrong _uuid
+    // =============================================================
+    console.log('[r1] semaphore (max=2): force-unlock with wrong _uuid must NOT report unlocked:true while holders survive');
+    {
+        const broker = newBroker();
+        try {
+            const key = 'r1-sem';
+            const wsA = new FakeSocket();
+            const wsB = new FakeSocket();
+            const wsC = new FakeSocket();  // attacker / confused caller
+            broker.connectedClients.add(wsA);
+            broker.connectedClients.add(wsB);
+            broker.connectedClients.add(wsC);
+            broker.wsToKeys.set(wsA, {});
+            broker.wsToKeys.set(wsB, {});
+            broker.wsToKeys.set(wsC, {});
+            broker.wsToUUIDs.set(wsA, {});
+            broker.wsToUUIDs.set(wsB, {});
+            broker.wsToUUIDs.set(wsC, {});
+
+            const uA = uuidV4();
+            const uB = uuidV4();
+            const rA = lockSync(broker, wsA, {type: 'lock', uuid: uA, key, ttl: null, max: 2, force: false, pid: 1, retryCount: 0});
+            const rB = lockSync(broker, wsB, {type: 'lock', uuid: uB, key, ttl: null, max: 2, force: false, pid: 2, retryCount: 0});
+            assert.strictEqual(rA?.acquired, true, `wsA acquire failed: ${JSON.stringify(rA)}`);
+            assert.strictEqual(rB?.acquired, true, `wsB acquire failed: ${JSON.stringify(rB)}`);
+            assert.strictEqual(broker.locks.get(key).lockholders.size, 2, 'expected 2 holders after both acquires');
+
+            const uC = uuidV4();
+            const reply = unlockSync(broker, wsC, {type: 'unlock', uuid: uC, key, _uuid: 'WRONG-UUID', force: true});
+            const remaining = broker.locks.get(key)?.lockholders?.size ?? 0;
+
+            const reportedUnlocked = reply?.unlocked === true;
+            const survivedHolders = remaining;
+            console.log(`    reply.unlocked=${reportedUnlocked}, lockholders.size=${survivedHolders}`);
+            if (reportedUnlocked && survivedHolders >= 2) {
+                fail(`r1 PHANTOM-UNLOCK reproduced: reply.unlocked=true while ${survivedHolders} holders still in lockholders. reply=${JSON.stringify(reply)}`);
+            }
+            ok(`r1 OK: phantom-unlock prevented (reply=${JSON.stringify({unlocked: reply?.unlocked, error: reply?.error})}, holders=${survivedHolders})`);
+        } finally {
+            await new Promise<void>(r => broker.close(() => r()));
+        }
+    }
+
+    // =============================================================
+    // r2 — exclusive (max=1): wrong _uuid + force MUST NOT wipe valid holder
+    // =============================================================
+    console.log('\n[r2] exclusive (max=1): force-unlock with wrong _uuid must NOT evict the legitimate holder');
+    {
+        const broker = newBroker();
+        try {
+            const key = 'r2-excl';
+            const wsA = new FakeSocket();
+            const wsAttacker = new FakeSocket();
+            broker.connectedClients.add(wsA);
+            broker.connectedClients.add(wsAttacker);
+            broker.wsToKeys.set(wsA, {});
+            broker.wsToKeys.set(wsAttacker, {});
+            broker.wsToUUIDs.set(wsA, {});
+            broker.wsToUUIDs.set(wsAttacker, {});
+
+            const uA = uuidV4();
+            const rA = lockSync(broker, wsA, {type: 'lock', uuid: uA, key, ttl: null, max: 1, force: false, pid: 1, retryCount: 0});
+            assert.strictEqual(rA?.acquired, true);
+            assert.strictEqual(broker.locks.get(key).lockholders.size, 1);
+
+            const reply = unlockSync(broker, wsAttacker, {type: 'unlock', uuid: uuidV4(), key, _uuid: 'WRONG-UUID', force: true});
+            const remaining = broker.locks.get(key)?.lockholders?.size ?? 0;
+            const aStillHolder = broker.locks.get(key)?.lockholders?.has(uA) ?? false;
+            console.log(`    reply.unlocked=${reply?.unlocked}, lockholders.size=${remaining}, wsA still holder=${aStillHolder}`);
+            if (remaining === 0 || !aStillHolder) {
+                fail(`r2 OVER-EVICTION reproduced: attacker with wrong _uuid wiped legitimate holder. reply=${JSON.stringify(reply)}`);
+            }
+            ok(`r2 OK: legitimate holder survived attacker's wrong-_uuid force unlock`);
+        } finally {
+            await new Promise<void>(r => broker.close(() => r()));
+        }
+    }
+
+    // =============================================================
+    // r3 — cleanupConnection over-evicts a semaphore peer
+    // =============================================================
+    console.log('\n[r3] cleanupConnection on semaphore must only evict the closing client\'s holder, not peers');
+    {
+        const broker = newBroker();
+        try {
+            const key = 'r3-sem';
+            const wsA = new FakeSocket();
+            const wsB = new FakeSocket();
+            broker.connectedClients.add(wsA);
+            broker.connectedClients.add(wsB);
+            broker.wsToKeys.set(wsA, {});
+            broker.wsToKeys.set(wsB, {});
+            broker.wsToUUIDs.set(wsA, {});
+            broker.wsToUUIDs.set(wsB, {});
+
+            const uA = uuidV4();
+            const uB = uuidV4();
+            const rA = lockSync(broker, wsA, {type: 'lock', uuid: uA, key, ttl: null, max: 2, force: false, pid: 1, retryCount: 0});
+            const rB = lockSync(broker, wsB, {type: 'lock', uuid: uB, key, ttl: null, max: 2, force: false, pid: 2, retryCount: 0});
+            assert.strictEqual(rA?.acquired, true);
+            assert.strictEqual(rB?.acquired, true);
+            assert.strictEqual(broker.locks.get(key).lockholders.size, 2);
+
+            // wsA "disconnects" — broker's cleanupConnection runs.
+            broker.cleanupConnection(wsA);
+            const remaining = broker.locks.get(key)?.lockholders?.size ?? 0;
+            const bStillHolder = broker.locks.get(key)?.lockholders?.has(uB) ?? false;
+            console.log(`    after cleanup(wsA): lockholders.size=${remaining}, wsB still holder=${bStillHolder}`);
+            if (remaining !== 1 || !bStillHolder) {
+                fail(`r3 SEMAPHORE-COLLATERAL reproduced: cleanup of wsA evicted wsB. lockholders.size=${remaining}, B-holder=${bStillHolder}`);
+            }
+            ok(`r3 OK: peer wsB unaffected by wsA's disconnect; semaphore semantics preserved`);
+        } finally {
+            await new Promise<void>(r => broker.close(() => r()));
+        }
+    }
+
+    // =============================================================
+    // r4 — cleanupConnection notify-queue scrub: Object.keys(array)
+    //      iterates string indices, not uuids. The closing client's
+    //      queued waiter entries should be removed from `lck.notify`.
+    // =============================================================
+    console.log('\n[r4] cleanupConnection must remove the closing client\'s entries from lck.notify');
+    {
+        const broker = newBroker();
+        try {
+            const key = 'r4-busy';
+            const wsHolder = new FakeSocket();
+            const wsWaiter = new FakeSocket();
+            broker.connectedClients.add(wsHolder);
+            broker.connectedClients.add(wsWaiter);
+            broker.wsToKeys.set(wsHolder, {});
+            broker.wsToKeys.set(wsWaiter, {});
+            broker.wsToUUIDs.set(wsHolder, {});
+            broker.wsToUUIDs.set(wsWaiter, {});
+
+            const uH = uuidV4();
+            const uW = uuidV4();
+            lockSync(broker, wsHolder, {type: 'lock', uuid: uH, key, ttl: null, max: 1, force: false, pid: 1, retryCount: 0});
+            // wsWaiter's lock attempt enqueues since wsHolder owns it.
+            lockSync(broker, wsWaiter, {type: 'lock', uuid: uW, key, ttl: null, max: 1, force: false, pid: 2, retryCount: 0});
+
+            // Track the wsWaiter request in wsToUUIDs so cleanup tries to scrub it.
+            broker.wsToUUIDs.get(wsWaiter)[uW] = true;
+
+            const queueLenBefore = broker.locks.get(key)?.notify?.length ?? 0;
+            console.log(`    notify.length before cleanup(wsWaiter)=${queueLenBefore}`);
+
+            broker.cleanupConnection(wsWaiter);
+            const queueLenAfter = broker.locks.get(key)?.notify?.length ?? 0;
+            console.log(`    notify.length after cleanup(wsWaiter)=${queueLenAfter}`);
+
+            if (queueLenBefore < 1) {
+                fail(`r4 setup error: waiter never enqueued`);
+            }
+            if (queueLenAfter > 0) {
+                fail(`r4 NOTIFY-SCRUB-INDICES-BUG reproduced: closing client's queued entry survived cleanup; notify.length=${queueLenAfter}`);
+            }
+            ok(`r4 OK: closing client's notify entry removed (notify went ${queueLenBefore} -> ${queueLenAfter})`);
+        } finally {
+            await new Promise<void>(r => broker.close(() => r()));
+        }
+    }
+
+    clearTimeout(watchdog);
+    console.log('\n\u2705 unlock-race-test: all 4 scenarios passed');
+    process.exit(0);
+}
+
+main().catch(err => {
+    console.error('unlock-race-test threw:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Two latent races in `Broker1.unlock` (force-path) and `Broker1.cleanupConnection` were producing the user-visible **phantom unlock** symptom: a reply of `{unlocked:true}` while the lock object still listed the same holders, and an unrelated peer's hold disappearing because someone else's socket dropped.

### What was wrong

#### `Broker1.unlock` with `force=true`

* **Semaphore (`max>1`) + wrong `_uuid`** — the targeted-delete branch tried to delete `_uuid` from `lockholders` AFTER the unconditional delete earlier in the function, so the second `delete()` always returned `false` and `lockholdersAllReleased` was never set. The function still sent `{type:'unlock', unlocked:true}` even though no holder was removed and every peer was still in `lockholders`. **This is the phantom unlock.**
* **Exclusive (`max=1`) + wrong `_uuid`** — the same wrong-`_uuid` request fell into the `"Traditional force behavior - remove all lock holders"` branch and **evicted the legitimate holder**. An attacker (or a confused operator) could boot any holder by sending `{force:true, _uuid:'anything'}`.
* **Even on the happy path** (`force=true` + valid `_uuid`), `lockholdersAllReleased[_uuid]` was never set because of the double-delete, so a late retry of the same unlock fell through to `wrong-uuid` instead of being treated as idempotent.

#### `Broker1.cleanupConnection` (called on socket `'close'`/`'end'`/`'error'`)

* The notify-queue scrub iterated `Object.keys(uuids)` where `uuids` is already an `Array<string>`. `Object.keys(array)` returns string indices `'0','1','2',…`, **not the uuids** — so the closing client's queued waiter entries were never actually removed. A subsequent grant cycle would target a dead `ws`.
* The per-key cleanup called `unlock({force:true, key:k}, ws)` **with no `_uuid`**, which fell into the wipe-all branch. On `max=1` keys this happened to be correct (the closing client was the sole holder), but on `max>1` semaphore keys it evicted every peer holder regardless of which socket they were on. **A semaphore-using peer would silently lose its slot** the moment one TCP client disconnected.

### What's fixed

`Broker1.unlock` now distinguishes three force-mode dispositions explicitly:

| Case | New behavior |
|---|---|
| `force=true`, no `_uuid` | legacy wipe-all (used by operator force-release + cleanup path) — unchanged |
| `force=true`, `_uuid` matched | remove that one holder, set `lockholdersAllReleased[_uuid]=true` for late-unlock idempotency, drain queue |
| `force=true`, `_uuid` did NOT match | reply `{unlocked:false, error:"...no holder with _uuid='...'..."}`. **Leave every peer's hold alone.** |

`Broker1.cleanupConnection` now walks `lockObj.lockholders`, identifies the holders whose `holder.ws === closing_ws`, and unlocks each one individually with the matching `_uuid`. Peers keep their slots. The notify-queue scrub iterates the actual uuids.

## Tests

**`test/unlock-race-test.ts`** — 4 scenarios, all reproduce on `dev` HEAD and pass on this branch:

```
[r1] semaphore (max=2): force-unlock with wrong _uuid must NOT report unlocked:true while holders survive
    reply.unlocked=false, lockholders.size=2
  ✓ r1 OK: phantom-unlock prevented (reply={"unlocked":false,"error":"force-unlock: no holder with _uuid='WRONG-UUID' on key 'r1-sem' (max=2)."}, holders=2)

[r2] exclusive (max=1): force-unlock with wrong _uuid must NOT evict the legitimate holder
    reply.unlocked=false, lockholders.size=1, wsA still holder=true
  ✓ r2 OK: legitimate holder survived attacker's wrong-_uuid force unlock

[r3] cleanupConnection on semaphore must only evict the closing client's holder, not peers
    after cleanup(wsA): lockholders.size=1, wsB still holder=true
  ✓ r3 OK: peer wsB unaffected by wsA's disconnect; semaphore semantics preserved

[r4] cleanupConnection must remove the closing client's entries from lck.notify
    notify.length before cleanup(wsWaiter)=1
    notify.length after cleanup(wsWaiter)=0
  ✓ r4 OK: closing client's notify entry removed (notify went 1 -> 0)

✅ unlock-race-test: all 4 scenarios passed
```

**`test/ttl-sweeper-test.ts`** — 7 properties of the centralised TTL sweeper that complement the chaos-fuzz-extra `s10` scenario (which explicitly stops the auto-sweeper to drive synchronously). This one leaves the auto-sweeper running:

```
[t1-t3,t5] auto-sweeper evicts an expired holder; bookkeeping consistent
  ✓ t1: holder evicted by auto-sweeper within ttl + a few sweep intervals
  ✓ t2: deadline row removed alongside holder
  ✓ t3: lockholderTimeouts[<uuid>] = true (late-unlock idempotency marker)
  ✓ t5: ttlEvictionsTotal incremented (0 -> 1)

[t4] auto-sweeper triggers ensureNewLockHolder for a queued waiter
  ✓ t4: waiter received acquired:true after auto-sweep eviction

[t6] auto-sweeper leaves still-valid (long-TTL) holders alone
  ✓ t6: long-TTL holder + deadline row both still present after 250ms (10 sweep intervals)

[t7] stopTtlSweeper halts further evictions
  ✓ t7: holder survives past TTL when sweeper stopped (manual tickTtl required)
  ✓ t7: manual tickTtl evicted 1 entries after sweeper stop

✅ ttl-sweeper-test: all 7 properties verified
```

## Regression sweep — 16/16 green

`virtual-socket-test`, `virtual-socket-stress-test`, `in-process-bridge-test`, `admin-controls-test`, `admin-otel-toggle-test`, `quick-verification-test`, `improvements-test`, `rw-lock-simple-test`, `rw-rapid-cycles-test`, `quick-rw-test`, `rw-max-limits-test`, `rw-lock-standalone-test`, `comprehensive-rw-lock-test`, `acquire-many-queueing-test`, `chaos-fuzz-test`, `chaos-fuzz-extra-test`.

## Test plan

- [x] `npm run compile`
- [x] Both new tests fail on `dev` HEAD, pass on this branch
- [x] Full regression sweep — 16/16 tests green
- [ ] Roll into the cluster image once merged (a follow-up PR will bump `live-mutex-submodule` to `0.2.25-dd.4` after this lands; runtime change for cluster operators)

Made with [Cursor](https://cursor.com)