### PR TITLE
test: salvage facade error-event capture from stash

### DIFF
--- a/test/capture-logs-error-test.js
+++ b/test/capture-logs-error-test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  attachToBroker,
+  clearCapturedLogs,
+  disableLogCapture,
+  enableLogCapture,
+  getCapturedLogs,
+} = require('./capture-logs');
+
+test('capture helper subscribes to facade warning and error events', () => {
+  let warningListener;
+  let errorListener;
+  const facade = {
+    onWarning(listener) {
+      warningListener = listener;
+    },
+    onError(listener) {
+      errorListener = listener;
+    },
+  };
+
+  enableLogCapture();
+  try {
+    attachToBroker(facade);
+
+    assert.equal(typeof warningListener, 'function');
+    assert.equal(typeof errorListener, 'function');
+
+    warningListener('bounded warning');
+    errorListener(new Error('captured failure'));
+
+    const captured = getCapturedLogs();
+    assert.equal(captured.length, 2);
+    assert.deepEqual(
+      captured.map(({type, source}) => ({type, source})),
+      [
+        {type: 'warning', source: 'broker'},
+        {type: 'error', source: 'broker'},
+      ],
+    );
+    assert.equal(captured[0].message, 'bounded warning');
+    assert.match(captured[1].message, /^captured failure\nError: captured failure\n/);
+  } finally {
+    disableLogCapture();
+    clearCapturedLogs();
+  }
+});

--- a/test/capture-logs.js
+++ b/test/capture-logs.js
@@ -53,7 +53,7 @@ function addLog(type, source, message) {
     process.stderr.write(`${prefix} ${sourceLabel} ${message}\n`);
 }
 function attachWarningListener(instance, type) {
-    if (instance && typeof instance.onWarning === 'function') {
+    if (instance && typeof instance.onWarning === 'function' && typeof instance.onError === 'function') {
         instance.onWarning(function (...args) {
             const parts = args.map(arg => {
                 if (arg instanceof Error) {
@@ -63,6 +63,16 @@ function attachWarningListener(instance, type) {
             });
             const message = parts.join(' ');
             addLog('warning', type, message);
+        });
+        instance.onError(function (...args) {
+            const parts = args.map(arg => {
+                if (arg instanceof Error) {
+                    return arg.message + (arg.stack ? '\n' + arg.stack : '');
+                }
+                return String(arg);
+            });
+            const message = parts.join(' ');
+            addLog('error', type, message);
         });
     }
     else if (instance && instance.emitter) {

--- a/test/capture-logs.ts
+++ b/test/capture-logs.ts
@@ -1,6 +1,6 @@
 /**
  * Utility to capture broker and client logs for testing
- * Uses the new onWarning() method for clean log capture
+ * Uses the new onWarning() and onError() methods for clean log capture
  * Usage: import { attachToBroker, attachToClient, attachToRWClient } from './capture-logs';
  */
 
@@ -64,10 +64,10 @@ function addLog(type: LogEntry['type'], source: LogEntry['source'], message: str
 }
 
 /**
- * Helper to attach warning listener using the clean onWarning() method
+ * Helper to attach warning and error listeners using the clean onWarning() and onError() methods
  */
 function attachWarningListener(instance: any, type: 'broker' | 'client' | 'rw-client') {
-  if (instance && typeof instance.onWarning === 'function') {
+  if (instance && typeof instance.onWarning === 'function' && typeof instance.onError === 'function') {
     instance.onWarning(function(...args: any[]) {
       const parts = args.map(arg => {
         if (arg instanceof Error) {
@@ -80,8 +80,21 @@ function attachWarningListener(instance: any, type: 'broker' | 'client' | 'rw-cl
       // Add to logs
       addLog('warning', type, message);
     });
+    
+    instance.onError(function(...args: any[]) {
+      const parts = args.map(arg => {
+        if (arg instanceof Error) {
+          return arg.message + (arg.stack ? '\n' + arg.stack : '');
+        }
+        return String(arg);
+      });
+      const message = parts.join(' ');
+      
+      // Add to logs
+      addLog('error', type, message);
+    });
   } else if (instance && instance.emitter) {
-    // Fallback to emitter if onWarning not available
+    // Fallback to emitter if onWarning/onError not available
     instance.emitter.on('warning', (...args: any[]) => {
       const message = args.map(arg => 
         typeof arg === 'string' ? arg : (arg instanceof Error ? arg.message : JSON.stringify(arg))

--- a/test/capture-logs.ts
+++ b/test/capture-logs.ts
@@ -1,6 +1,6 @@
 /**
  * Utility to capture broker and client logs for testing
- * Uses the new onWarning() and onError() methods for clean log capture
+ * Uses the onWarning() and onError() methods for clean log capture
  * Usage: import { attachToBroker, attachToClient, attachToRWClient } from './capture-logs';
  */
 
@@ -55,7 +55,7 @@ function addLog(type: LogEntry['type'], source: LogEntry['source'], message: str
     message: typeof message === 'string' ? message : JSON.stringify(message),
     timestamp: Date.now(),
   });
-  
+
   // Always write to stderr to ensure inactivity timeout can detect activity
   // This ensures the test runner knows the process is still alive
   const prefix = type === 'error' ? '❌' : type === 'warning' ? '⚠️' : 'ℹ️';
@@ -76,11 +76,11 @@ function attachWarningListener(instance: any, type: 'broker' | 'client' | 'rw-cl
         return String(arg);
       });
       const message = parts.join(' ');
-      
+
       // Add to logs
       addLog('warning', type, message);
     });
-    
+
     instance.onError(function(...args: any[]) {
       const parts = args.map(arg => {
         if (arg instanceof Error) {
@@ -89,7 +89,7 @@ function attachWarningListener(instance: any, type: 'broker' | 'client' | 'rw-cl
         return String(arg);
       });
       const message = parts.join(' ');
-      
+
       // Add to logs
       addLog('error', type, message);
     });
@@ -101,7 +101,7 @@ function attachWarningListener(instance: any, type: 'broker' | 'client' | 'rw-cl
       ).join(' ');
       addLog('warning', type, message);
     });
-    
+
     instance.emitter.on('error', (...args: any[]) => {
       const message = args.map(arg => 
         typeof arg === 'string' ? arg : (arg instanceof Error ? arg.message : JSON.stringify(arg))
@@ -112,21 +112,21 @@ function attachWarningListener(instance: any, type: 'broker' | 'client' | 'rw-cl
 }
 
 /**
- * Attach log capture to a broker instance using onWarning()
+ * Attach warning and error capture to a broker instance.
  */
 export function attachToBroker(broker: any) {
   attachWarningListener(broker, 'broker');
 }
 
 /**
- * Attach log capture to a client instance using onWarning()
+ * Attach warning and error capture to a client instance.
  */
 export function attachToClient(client: any) {
   attachWarningListener(client, 'client');
 }
 
 /**
- * Attach log capture to an RW client instance using onWarning()
+ * Attach warning and error capture to an RW client instance.
  */
 export function attachToRWClient(client: any) {
   attachWarningListener(client, 'rw-client');


### PR DESCRIPTION
## Salvage source

This PR reincorporates the one still-useful hunk from the preserved local stash `d675e518` (`On dev: My semaphore fix and other changes`, created 2025-11-15). The stash remains untouched and is additionally protected locally at `refs/rescue/stashes/20260829-live-mutex-semaphore`.

The first commit was made from only `test/capture-logs.{ts,js}` at the stash tree and then cherry-picked onto current `origin/dev`. The second commit adds a regression test and removes trailing whitespace inherited from the stash.

## What was recovered

When an object exposes the public `onWarning()` facade, the existing helper takes that path instead of listening directly to its emitter. The helper did not also subscribe through `onError()`, so error events silently disappeared from captured test diagnostics. The stash contained the missing facade subscription.

## What was not restored

- conflict-marked `package.json` content;
- older semaphore-limit logic now superseded by the current `maxRead`/`maxWrite` and effective-count implementation;
- release-timeout handling already present on `dev` in stronger TypeScript and JavaScript forms;
- listener APIs and compiler changes already incorporated by later commits; and
- unrelated old test rewrites.

## Validation

- `node --test test/capture-logs-error-test.js`: passed (1/1)
- `npm run compile -- --pretty false`: passed
- `npm run compile:test -- --pretty false`: passed after the required source compile populated `dist/`
- `git diff --check origin/dev..HEAD`: passed
- `gitleaks git --redact --no-banner --log-opts='origin/dev..HEAD' .`: passed (2 commits, no leaks)

The unchanged repository baseline still triggers two generic-key findings in `.coveralls.yml` and `readme.md`; neither is introduced or modified here.
