### PR TITLE
DEN-4233 add encrypted runtime and CI secret placeholders

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,21 @@
+# Public age recipients only. Private identities never enter Git.
+# Bootstrap fleet recipients; split dev/prod recipients before production rollout.
+keys:
+  - &operator age1qrnva7lnv2jzww6ah5au0cqm4wkvkm5shpzflekdcm4nlu6wnyfqgfaxft
+  - &recovery age1txv6jzlds2s03advmdtnm5l93qh4rkqs50nwvzk9yfvsartzue8se8t7jv
+
+creation_rules:
+  - path_regex: ^env/enc/dev\.env\.enc$
+    input_type: dotenv
+    output_type: dotenv
+    key_groups:
+      - age:
+          - *operator
+          - *recovery
+  - path_regex: ^env/enc/prod\.env\.enc$
+    input_type: dotenv
+    output_type: dotenv
+    key_groups:
+      - age:
+          - *operator
+          - *recovery

--- a/env/enc/dev.env.enc
+++ b/env/enc/dev.env.enc
@@ -1,0 +1,17 @@
+SHARED_AUTH_READ_TOKEN=ENC[AES256_GCM,data:0QBqhO5y3ranQkYzpbyyELu3nrgRPY3XYfu4loelDzFm6EO2IL5SrhcNbgc=,iv:whnVrulj0FHYdMTQ32hy2VDh49z4HTHVqcc4hIW7WZI=,tag:uJeBmiv3U1N88NVFw2dz+g==,type:str]
+DOCKERHUB_USERNAME=ENC[AES256_GCM,data:RMYSsXTPWpM5HnsZR6MZGTHtp3NJ1y8ntlfZXCr8gIbdy1Y=,iv:DB9ECrgGLHbW8n9O2MDA2KvMBHSoysupQfyYyIIghc0=,tag:AwpTSeR3KEbQRHFXZhApKQ==,type:str]
+DOCKERHUB_TOKEN=ENC[AES256_GCM,data:3v85MkchTsZ3uiVmKs1oy+EifslEGGn2Bq27q5bCc75j5SpwiQ==,iv:WOeKOKHf+7ycP3R6/WxmEO2ZBP9ICg6SjeCJSuJIMCA=,tag:5mxLF7JCQu8yk4FIlxJOXQ==,type:str]
+GCP_WORKLOAD_IDENTITY_PROVIDER=ENC[AES256_GCM,data:gFDQsbC0Zfby7Vrrtt41OfhLoXMpAyiUVjemyIg1X0S2hP9wKdoQMAjSMWbv9hs=,iv:/goRhrCQauv4GCn9lNs5Z2PY69j8Ki1fqeDtLoYm1Lc=,tag:TcVLHXflniJwFREG+z2X/A==,type:str]
+GCP_SERVICE_ACCOUNT=ENC[AES256_GCM,data:OJOL/qwTZRv/hUylaqtZ3P/uHbN2u9W2CUfAqul4oyfdsv0D,iv:6XX8i6VnGdktvQaOOyANpLMNR4yjPdtE8rOykuKh7pw=,tag:bstywl098IBTj8Wfug2GDA==,type:str]
+FLY_API_TOKEN=ENC[AES256_GCM,data:xHSxYAxzkissdNyaKKE94Xb46MEWlJTu/GfS6lR5ULV6Peg=,iv:oBu6ou3PPLlANVvB+ufMwblmKEsejpdc908diIUDAX8=,tag:Ovq7XdiTmyY2CF3XoEZqYQ==,type:str]
+LMX_AUTH_TOKEN=ENC[AES256_GCM,data:RzNrKZpO21wOZ++0H8vg2oXvOUtacHa676zprv4oIyivJ89I,iv:3lfBXS7qzCJj9VZc6Gys9JMt3Ov5WTnd5ZNJJ/romXI=,tag:sYQJhRy/3nDcLk98l40xTQ==,type:str]
+LMX_ADMIN_TOKEN=ENC[AES256_GCM,data:styLR2aZq9UH9rZQcc52xsJT3x7EnAEMrAVJVmhXN5oo2iYvdQ==,iv:Ayz2ksJmpZjt6otOGvwFTMFkiZkUylWAUmScOMWS7ng=,tag:15oKLydauyaTJY2cxak97w==,type:str]
+COVERALLS_REPO_TOKEN=ENC[AES256_GCM,data:T6TIqYw7FCjc03uL0D2GEs3WqOvLvGUuhdIPzHcolhi53i011IBa9GrQ,iv:ZQ2ita/l9MqA7oYCqxLkbG32XMTXjb1cnv9SEKThXbs=,tag:zQgOy+H+JYRfADQmmB2Wog==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPcDdJQ1duREUrYk1pQWpT\nNjJOcG9XOUNqUVozUndnM2p0c1l5MTZJV2g0Ck03VURmQ0hSRWhpYlY2dlFyc3B5\nQ3kyVlNsWHNQMGN1WTRFLzB6UFlHUWsKLS0tIEM2YWlWZGZsVHZ0RUJTSTR6UWYr\nTVZPUzZ2RXVVaXNiV05GazZieEgxOVkKbYl81XcJXrtSf3AG4vtpfliOgDVeEFqC\n/tfIF41dSROhY9IaHy/PPycL06THi92gJsbq0qgil8t5udfcR5Ieog==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1qrnva7lnv2jzww6ah5au0cqm4wkvkm5shpzflekdcm4nlu6wnyfqgfaxft
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnWEpLK2twQm5iRkM3N01i\nMG5sdUpTR3FnTUxRcG5qdWRkRUR4QmUrQUNnCis1aTYvSFpOMU1GeUZsRWZ3RWFu\nVUZENk11YVBLN0hXRlJ0MGc0RXpyRGcKLS0tIFhqZVpCRW9seU9XQ3EwL3Q2emlR\nMFdoRnhSQzdDdWQ1T0RKRHc0RGZhcEUKfJrVfqHU4eI6KVDI9GsitAs9x7jTjwt/\nOZtuCBO+ksDhccu1BdIXLTe+Os+y63oA9aY6Serjzaaf2uB11zGSWg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age1txv6jzlds2s03advmdtnm5l93qh4rkqs50nwvzk9yfvsartzue8se8t7jv
+sops_lastmodified=2026-09-09T19:39:09Z
+sops_mac=ENC[AES256_GCM,data:qDff0kMlslY5oQyvYLzI+qBLLtTCBPpgmn0DSwhpofj4a5m/U0/Z4Y6aOuMMxvMg1A9HOhaRqYNvWV4cNk4YtAQLEfusXqOeuMml42txr3YMQMmczDbPcYnQaDCwu6/fBM8EARJvMmcElwI+RbghhsfC5FiwvCPox+QRgh3Qj3U=,iv:acyIoviG0H9CSlF5RSgQAHMBoB70hp8ekNC3mcHHvEQ=,tag:EpcszM/le4I0smSRk+tZCQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3

--- a/env/enc/prod.env.enc
+++ b/env/enc/prod.env.enc
@@ -1,0 +1,17 @@
+SHARED_AUTH_READ_TOKEN=ENC[AES256_GCM,data:42zLTC2Y4JuK9GnyWzsG26MC9zZDvvezF9m9lFazE6HCajWCS5NKSX00pS9nimr7,iv:MUV90Trc7WGogI1ymLvnjszu0taAxbtb/ZJt0qpfqkg=,tag:s+Ev2zX8vNHzbSK+AQ6zug==,type:str]
+DOCKERHUB_USERNAME=ENC[AES256_GCM,data:k4geghm4y+HVTyE0Kdh7EQUD1iO5It9eKCbKYSevmPpI6LWl7DWtDVaeWas=,iv:ebPHocXjXshHj3UZWOFM2bg6eyLsfQvwsiUY7Ap0wGk=,tag:jF0tU2LbwLtwhvV1yD1+Og==,type:str]
+DOCKERHUB_TOKEN=ENC[AES256_GCM,data:gzv2cJfX8rWTglSsw3ang/NujjCgGsjcl3N01/wafMH6GIiFFfr9AcM=,iv:DcTRlyUyQP5OB9rFq/H3RdEjnIJgfY+vSTCo6Qcf2OU=,tag:t4vhiZpQ9yMCauDb/uhTWw==,type:str]
+GCP_WORKLOAD_IDENTITY_PROVIDER=ENC[AES256_GCM,data:LSVqjNFoziktMRzMzr/HsBBsbG2BkIpU+oHnlaibwNoak5jYynxEXCshiPEfL4bOwA/HowDuwvQ=,iv:Ck/PqUBqrvw7RcaUJt5cm5YbL6s9T+xnodRQ1j5iS+g=,tag:+Dv5PfIzt59D3YS5yBenbw==,type:str]
+GCP_SERVICE_ACCOUNT=ENC[AES256_GCM,data:z9nj59pmGktjHOHFClzcpChwmTTzHGVao+4PILutzzGa2YAPe1uVNmbGy+mc,iv:jFgj3C5KIH1VUmjJ0rj6+mbmGNf0F5GLqZ7dbdLU03U=,tag:MinoDAy17JrETWkvpBZbcA==,type:str]
+FLY_API_TOKEN=ENC[AES256_GCM,data:JeL8s1JhzCYcH6UddEPM4wQrUq6BEtUOBEa+t9Dus6JqZX2745Ku,iv:+j0vG4NCKjkiaK4rSitA05zKU8oa0UORN0VQp28T4J0=,tag:XmVYeunbpj/wpkv1w7ukAw==,type:str]
+LMX_AUTH_TOKEN=ENC[AES256_GCM,data:Efxy7n9GFagbMDf0WjJaf2/CGUEqITGRMucfDuH8C6/PUx5q2MkHQg==,iv:0rODabWE/eapv1Dy0EZKsC9kQPNDif9ovif2Coey7pU=,tag:G1QECsmxivvCn/14AY7A+A==,type:str]
+LMX_ADMIN_TOKEN=ENC[AES256_GCM,data:h6ugtMG9bRiMyUcVHf0i/xX5kOP03UqKCKpeJaT1Ks8SQ5pmN8rLgvg=,iv:mwCPTPgIMpEzZq2jOgccva0sO4edEYNl7u8Gi6c94eY=,tag:DQ24LA3sjQzHWKIKvzJDSA==,type:str]
+COVERALLS_REPO_TOKEN=ENC[AES256_GCM,data:CL9JG4kRTFfOSQwlZ8pZ6BCTUd+8O2krax1Sf9DlbEJtCgmejE2U3HujVNQSAg==,iv:+vB8CLVefDAgXHDtpaWZ7HlKRuuztZ2ZZTUAquTi8DY=,tag:E4TibGukUsmvdUQpuE/1kA==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1V0xLMitoZEJFWGJlUktD\nOVhralpwelVrM29QaWN3V0hZb3haVXRIOXhRCll1SUVvbXZ1d0RTQXdTTU12bzlE\nQnBxM056QzdzVkRmMTFOUkZSWEpud1kKLS0tIC9veUw4UGFidG9CL0JFSk54bktD\nQXpLMVM3b3ZUMXQwSDRDSlZDLzJDU3cKwaWKN3w9kzSNQaVW1CYUZaHyI4iYXNBv\nFbk+2y9iWXuKMfvQWN7Mln9HQC7WGBoV7laUOd/XF0F0syJgW5a6tg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1qrnva7lnv2jzww6ah5au0cqm4wkvkm5shpzflekdcm4nlu6wnyfqgfaxft
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiK0VkUCtRVnVWQ2R0SFFk\nR3IwdWVEdGFZTzluQlIzZ2J5d0NaTzhzNUEwCkk4SDZKaHlWaWR0SFlJeUdmNWk3\nRTZ4WFNTNXU4QVhxMVc1Q3ZwdUJpVTgKLS0tICszQUFvQTRLTUZEWWxad1k2N1dJ\nenp5VEhOVkhLYkZFY2ttMHdCUVgrNDAK4FCf0w5xs0wm9CJf4QaA+4E8XOT/RkY1\n9eFixtSi9noM3U5QNC97lZ3jgz71c06kzsY9JICypAAnUbGpBbbEQQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age1txv6jzlds2s03advmdtnm5l93qh4rkqs50nwvzk9yfvsartzue8se8t7jv
+sops_lastmodified=2026-09-09T19:39:09Z
+sops_mac=ENC[AES256_GCM,data:CxWq+696XmgRcmptcCYCM0Y6VA2rLFX7UdOvSlHUgQXwwW4azNfiDucgZd0Q9vwKrH+twMGq90Q7gPdgOIc7QcMP0Kg2VmIDQUQDOwHAUfUa2+KnWdFqHVF0SSHMjjt6Ej9aPD+a1ljThsgr9u/PyWsraAJVWTEhz8cCYH4QD3g=,iv:D5VAX4PkJYfjUSPTckuaMtTvlI5JiVPI6F2DZdyuXZ0=,tag:TEiDynk5xvlx3I/L16xGyQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3


### PR DESCRIPTION
Adds canonical dev/prod SOPS dotenv ciphertext for the image workflow and repo-specific runtime/deploy credentials: `SHARED_AUTH_READ_TOKEN`, Docker Hub/GCP fields, `FLY_API_TOKEN`, `LMX_AUTH_TOKEN`, `LMX_ADMIN_TOKEN`, and `COVERALLS_REPO_TOKEN`.

All newly added values are explicit non-secret placeholders. The audit also found credential material already tracked in `.coveralls.yml`; that existing value is treated as exposed and was not copied into the new bundle or rotated here. It should be revoked/rotated through the approved credential lifecycle and the tracked literal scrubbed in a follow-up security change.

No auth check is bypassed.