### PR TITLE
branch: live-mutex: repair/live-mutex-images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -19,15 +19,29 @@ jobs:
   dkf-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with: { node-version: 22 }
-      - run: curl -fsSL https://raw.githubusercontent.com/ORESoftware/ores-gha-workflows/main/scripts/render-dkf.mjs -o /tmp/render-dkf.mjs && node /tmp/render-dkf.mjs . --check
+      - name: Verify derived Dockerfiles with the pinned renderer
+        shell: bash
+        env:
+          POLICY_REVISION: 09317aaf8f89a58b9ee87755db4daa2b242d6cb2
+          RENDERER_SHA256: 5224d54745f5f04b043897530f0b2d820e4985df1b961e71d71f4a1e4017876a
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+            "https://raw.githubusercontent.com/ORESoftware/ores-gha-workflows/${POLICY_REVISION}/scripts/render-dkf.mjs" \
+            --output /tmp/render-dkf.mjs
+          printf '%s  %s\n' "$RENDERER_SHA256" /tmp/render-dkf.mjs | sha256sum --check --strict -
+          node /tmp/render-dkf.mjs . --check
   images:
     needs: dkf-drift
-    uses: ORESoftware/ores-gha-workflows/.github/workflows/container-images.yml@main
+    uses: ORESoftware/ores-gha-workflows/.github/workflows/container-images.yml@09317aaf8f89a58b9ee87755db4daa2b242d6cb2
     with:
       image-name: oresoftware/live-mutex
+      push: ${{ github.ref == 'refs/heads/main' }}
       gcp-project: 
       dockerhub-namespace: oresoftware
     secrets:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,38 @@
+# Caller: copy to <repo>/.github/workflows/images.yml. Builds Dockerfile.arm64.dkf + Dockerfile.x86-64.dkf
+# (or Dockerfile) and pushes to GHCR, GCP Artifact Registry (<gcp-project> = this org's project) and the
+# private Docker Hub namespace. Secrets are org-level: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN,
+# GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT (OIDC, no JSON keys).
+name: images
+on:
+  push:
+    branches: [main]
+    paths: ["Dockerfile", "Dockerfile.*.dkf", "src/**", "Cargo.*", "package*.json", "pubspec.*", "go.*", "gleam.toml", "manifest.toml"]
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+concurrency:
+  group: images-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  dkf-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22 }
+      - run: curl -fsSL https://raw.githubusercontent.com/ORESoftware/ores-gha-workflows/main/scripts/render-dkf.mjs -o /tmp/render-dkf.mjs && node /tmp/render-dkf.mjs . --check
+  images:
+    needs: dkf-drift
+    uses: ORESoftware/ores-gha-workflows/.github/workflows/container-images.yml@main
+    with:
+      image-name: oresoftware/live-mutex
+      gcp-project: 
+      dockerhub-namespace: oresoftware
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      BUILD_SECRET_GITHUB_TOKEN: ${{ secrets.SHARED_AUTH_READ_TOKEN }}

--- a/Dockerfile.arm64.dkf
+++ b/Dockerfile.arm64.dkf
@@ -1,0 +1,32 @@
+# GENERATED from Dockerfile (sha256:757b72e7ef3bc738) by ores-gha-workflows/scripts/render-dkf.mjs — target linux/arm64. Do not edit; edit Dockerfile and re-render.
+FROM --platform=linux/arm64 node:12.3.1-alpine
+ARG TARGETARCH
+
+ENV live_mutex_host "0.0.0.0"
+ENV live_mutex_port 6970
+ENV lmx_in_docker='yes'
+
+ENV FORCE_COLOR=1
+
+USER root
+RUN echo "user is: $USER"
+
+WORKDIR "/app"
+
+COPY package.json .
+COPY package-lock.json .
+COPY assets assets
+
+RUN npm i
+
+COPY . .
+
+ARG CACHEBUST=1
+
+ENV bunion_producer_level='WARN'
+
+EXPOSE 6970:6970
+
+ENTRYPOINT ["node", "dist/lm-start-server.js"]
+CMD []
+

--- a/Dockerfile.x86-64.dkf
+++ b/Dockerfile.x86-64.dkf
@@ -1,0 +1,32 @@
+# GENERATED from Dockerfile (sha256:757b72e7ef3bc738) by ores-gha-workflows/scripts/render-dkf.mjs — target linux/amd64. Do not edit; edit Dockerfile and re-render.
+FROM --platform=linux/amd64 node:12.3.1-alpine
+ARG TARGETARCH
+
+ENV live_mutex_host "0.0.0.0"
+ENV live_mutex_port 6970
+ENV lmx_in_docker='yes'
+
+ENV FORCE_COLOR=1
+
+USER root
+RUN echo "user is: $USER"
+
+WORKDIR "/app"
+
+COPY package.json .
+COPY package-lock.json .
+COPY assets assets
+
+RUN npm i
+
+COPY . .
+
+ARG CACHEBUST=1
+
+ENV bunion_producer_level='WARN'
+
+EXPOSE 6970:6970
+
+ENTRYPOINT ["node", "dist/lm-start-server.js"]
+CMD []
+


### PR DESCRIPTION
Fleet sync 20260911 from the citadel Mac (~/codes/ores/live-mutex).

Branch `repair/live-mutex-images` carries 2 commit(s) not on `dev`;  3 files changed, 116 insertions(+)

Files:
- .github/workflows/images.yml
- Dockerfile.arm64.dkf
- Dockerfile.x86-64.dkf

Rules followed: no rebase, no stash, no reset, no force-push; conflicts (if any) are resolved semantically per oresoftware/my-ai/AGENTS.md before this is marked ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7RjB22qc4AaKq4zqeVBVY